### PR TITLE
Add Xoodoo implementation for aarch64 intrinsics.

### DIFF
--- a/src/xoodoo/impl_aarch64.rs
+++ b/src/xoodoo/impl_aarch64.rs
@@ -1,0 +1,51 @@
+use core::arch::aarch64::*;
+
+use super::{Xoodoo, ROUND_KEYS};
+
+impl Xoodoo {
+    #[allow(
+        non_upper_case_globals,
+        clippy::many_single_char_names,
+        clippy::cast_ptr_alignment
+    )]
+    pub fn permute(&mut self) {
+        macro_rules! rol32in128 {
+            ($x:ident, $b:literal) => {
+                vsriq_n_u32::<{ 32 - $b }>(vshlq_n_u32::<$b>($x), $x)
+            };
+        }
+
+        unsafe {
+            let mut a = vld1q_u32(self.st.as_ptr().add(0));
+            let mut b = vld1q_u32(self.st.as_ptr().add(4));
+            let mut c = vld1q_u32(self.st.as_ptr().add(8));
+
+            for &round_key in &ROUND_KEYS {
+                let mut d = veorq_u32(veorq_u32(a, b), c);
+                d = vextq_u32::<3>(d, d);
+                let mut e = rol32in128!(d, 5);
+                let mut f = rol32in128!(d, 14);
+                e = veorq_u32(e, f);
+                a = veorq_u32(a, e);
+                b = veorq_u32(b, e);
+                f = veorq_u32(c, e);
+                c = rol32in128!(f, 11);
+                b = vextq_u32::<3>(b, b);
+                a = veorq_u32(a, vsetq_lane_u32::<0>(round_key, vmovq_n_u32(0)));
+                e = vbicq_u32(c, b);
+                d = vbicq_u32(a, c);
+                f = vbicq_u32(b, a);
+                a = veorq_u32(a, e);
+                d = veorq_u32(b, d);
+                c = veorq_u32(c, f);
+                f = vextq_u32::<2>(c, c);
+                b = rol32in128!(d, 1);
+                c = rol32in128!(f, 8);
+            }
+
+            vst1q_u32(self.st.as_ptr().add(0) as *mut _, a);
+            vst1q_u32(self.st.as_ptr().add(4) as *mut _, b);
+            vst1q_u32(self.st.as_ptr().add(8) as *mut _, c);
+        }
+    }
+}

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -1,7 +1,9 @@
 use rawbytes::RawBytes;
 use zeroize::Zeroize;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(target_arch = "aarch64")]
+mod impl_aarch64;
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
 mod impl_portable;
 #[cfg(target_arch = "x86_64")]
 mod impl_x86_64;


### PR DESCRIPTION
This adds `impl_aarch64.rs` with an implementation using `core::arch::aarch64::*` intrinsic operations, based largely on your [charm](https://github.com/jedisct1/charm/blob/master/src/charm.c#L81) implementation.

It passes all tests, but is (on my Apple M1 Macbook Air, at least) dramatically slower than the portable implementation, as tested with Rust 1.59:

```
Xoodoo permutation      time:   [103.61 ns 103.64 ns 103.68 ns]                               
                        change: [+40.143% +40.300% +40.432%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

Xoodyak hash            time:   [2.0161 us 2.0167 us 2.0174 us]                          
                        change: [+52.145% +52.312% +52.467%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

Xoodyak keyed           time:   [861.59 ns 861.98 ns 862.40 ns]                           
                        change: [+54.195% +54.346% +54.510%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
```

The emitted assembly seems right:

```asm
	.section	__TEXT,__text,regular,pure_instructions
	.globl	__ZN7xoodyak6xoodoo12impl_aarch6441_$LT$impl$u20$xoodyak..xoodoo..Xoodoo$GT$7permute17h0b60b2dff5436c73E
	.p2align	2
__ZN7xoodyak6xoodoo12impl_aarch6441_$LT$impl$u20$xoodyak..xoodoo..Xoodoo$GT$7permute17h0b60b2dff5436c73E:
	.cfi_startproc
	mov	x8, #0
	ldp	q0, q1, [x0]
	ldr	q2, [x0, #32]
Lloh12:
	adrp	x9, l_anon.ec63ad25e19e563a1a8fa134423dd5f9.9@PAGE
Lloh13:
	add	x9, x9, l_anon.ec63ad25e19e563a1a8fa134423dd5f9.9@PAGEOFF
LBB11_1:
	add	x10, x9, x8
	eor.16b	v3, v1, v2
	eor.16b	v3, v3, v0
	ext.16b	v3, v3, v3, #12
	shl.4s	v4, v3, #5
	sri.4s	v4, v3, #27
	shl.4s	v5, v3, #14
	sri.4s	v5, v3, #18
	eor.16b	v3, v5, v4
	eor.16b	v1, v3, v1
	eor.16b	v2, v3, v2
	shl.4s	v4, v2, #11
	sri.4s	v4, v2, #21
	ext.16b	v1, v1, v1, #12
	movi.16b	v2, #0
	ld1.s	{ v2 }[0], [x10]
	eor.16b	v0, v2, v0
	eor.16b	v0, v0, v3
	bic.16b	v2, v4, v1
	bic.16b	v3, v0, v4
	bic.16b	v5, v1, v0
	eor.16b	v0, v2, v0
	eor.16b	v2, v3, v1
	eor.16b	v1, v5, v4
	ext.16b	v3, v1, v1, #8
	shl.4s	v1, v2, #1
	sri.4s	v1, v2, #31
	shl.4s	v2, v3, #8
	sri.4s	v2, v3, #24
	add	x8, x8, #4
	cmp	x8, #48
	b.ne	LBB11_1
	stp	q0, q1, [x0]
	str	q2, [x0, #32]
	ret
	.loh AdrpAdd	Lloh12, Lloh13
	.cfi_endproc
```

The two possibilities I can imagine are:

1. I’m doing something wrong with the implementation.
2. The NEON intrinsics are just slower for Xoodoo.

I figured I’d create a draft PR for this in case I’m missing something important, or at least to leave a paper trail that this approach doesn’t work.