### PR TITLE
Rewrite portable implementation for slight perf win.

### DIFF
--- a/src/xoodoo/impl_portable.rs
+++ b/src/xoodoo/impl_portable.rs
@@ -1,31 +1,55 @@
 use super::{Xoodoo, ROUND_KEYS};
 
 impl Xoodoo {
-    #[inline]
+    #[inline(always)]
     fn round(&mut self, round_key: u32) {
         let st = &mut self.st;
-        let mut e = [0u32; 4];
-        for i in 0..4 {
-            e[i] = (st[i] ^ st[i + 4] ^ st[i + 8]).rotate_right(18);
-            e[i] ^= e[i].rotate_right(9);
-        }
-        for i in 0..12 {
-            st[i] ^= e[(i.wrapping_sub(1)) & 3];
-        }
-        st.swap(7, 4);
-        st.swap(7, 5);
-        st.swap(7, 6);
-        st[0] ^= round_key;
-        for i in 0..4 {
-            let a = st[i];
-            let b = st[i + 4];
-            let c = st[i + 8].rotate_right(21);
-            st[i + 8] = ((b & !a) ^ c).rotate_right(24);
-            st[i + 4] = ((a & !c) ^ b).rotate_right(31);
-            st[i] ^= c & !b;
-        }
-        st.swap(8, 10);
-        st.swap(9, 11);
+
+        let p = [
+            st[0] ^ st[4] ^ st[8],
+            st[1] ^ st[5] ^ st[9],
+            st[2] ^ st[6] ^ st[10],
+            st[3] ^ st[7] ^ st[11],
+        ];
+
+        let e = [
+            p[3].rotate_left(5) ^ p[3].rotate_left(14),
+            p[0].rotate_left(5) ^ p[0].rotate_left(14),
+            p[1].rotate_left(5) ^ p[1].rotate_left(14),
+            p[2].rotate_left(5) ^ p[2].rotate_left(14),
+        ];
+
+        let mut tmp = [0u32; 12];
+
+        tmp[0] = e[0] ^ st[0] ^ round_key;
+        tmp[1] = e[1] ^ st[1];
+        tmp[2] = e[2] ^ st[2];
+        tmp[3] = e[3] ^ st[3];
+
+        tmp[4] = e[3] ^ st[7];
+        tmp[5] = e[0] ^ st[4];
+        tmp[6] = e[1] ^ st[5];
+        tmp[7] = e[2] ^ st[6];
+
+        tmp[8] = (e[0] ^ st[8]).rotate_left(11);
+        tmp[9] = (e[1] ^ st[9]).rotate_left(11);
+        tmp[10] = (e[2] ^ st[10]).rotate_left(11);
+        tmp[11] = (e[3] ^ st[11]).rotate_left(11);
+
+        st[0] = (!tmp[4] & tmp[8]) ^ tmp[0];
+        st[1] = (!tmp[5] & tmp[9]) ^ tmp[1];
+        st[2] = (!tmp[6] & tmp[10]) ^ tmp[2];
+        st[3] = (!tmp[7] & tmp[11]) ^ tmp[3];
+
+        st[4] = ((!tmp[8] & tmp[0]) ^ tmp[4]).rotate_left(1);
+        st[5] = ((!tmp[9] & tmp[1]) ^ tmp[5]).rotate_left(1);
+        st[6] = ((!tmp[10] & tmp[2]) ^ tmp[6]).rotate_left(1);
+        st[7] = ((!tmp[11] & tmp[3]) ^ tmp[7]).rotate_left(1);
+
+        st[8] = ((!tmp[2] & tmp[6]) ^ tmp[10]).rotate_left(8);
+        st[9] = ((!tmp[3] & tmp[7]) ^ tmp[11]).rotate_left(8);
+        st[10] = ((!tmp[0] & tmp[4]) ^ tmp[8]).rotate_left(8);
+        st[11] = ((!tmp[1] & tmp[5]) ^ tmp[9]).rotate_left(8);
     }
 
     pub fn permute(&mut self) {


### PR DESCRIPTION
~3% speed improvement on the M1:

```
Xoodoo permutation      time:   [71.380 ns 71.439 ns 71.498 ns]                               
                        change: [-3.5832% -3.4892% -3.3789%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Xoodyak hash            time:   [1.2899 us 1.2905 us 1.2913 us]                          
                        change: [-1.7372% -1.4566% -1.1911%] (p = 0.00 < 0.05)
                        Performance has improved.

Xoodyak keyed           time:   [550.43 ns 550.63 ns 550.83 ns]                           
                        change: [-1.8320% -1.7599% -1.6869%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```

This translates into similarly mild improvements in real-world usage. A test app which hashes a 100MiB file:

```
Benchmark 1: control
  Time (mean ± σ):     494.6 ms ±   0.5 ms    [User: 495.4 ms, System: 33.0 ms]
  Range (min … max):   493.5 ms … 495.0 ms    10 runs
 
Benchmark 2: experimental
  Time (mean ± σ):     483.4 ms ±   0.7 ms    [User: 484.4 ms, System: 32.2 ms]
  Range (min … max):   482.8 ms … 485.2 ms    10 runs
 
Summary
  'experimental' ran
    1.02 ± 0.00 times faster than ‘control'
```

That said, it uses a little more memory and may well be slower on other processors/architectures. I’d totally understand if you’d prefer the existing implementation.