### PR TITLE
Support for `no_std` environments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,5 +15,11 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
+    - name: Build (no_std)
+      run: cargo build --verbose --no-default-features
+    - name: Build (thumbv7m-none-eabi)
+      run: cargo build --verbose --no-default-features --target thumbv7m-none-eabi
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests (no_std)
+      run: cargo test --verbose --no-default-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: thumbv7m-none-eabi
     - name: Build
       run: cargo build --verbose
     - name: Build (no_std)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["no-std", "cryptography", "wasm"]
 
 [features]
 default = ["std"]
-std = []
+std = ["zeroize/alloc"]
 
 [dependencies]
-zeroize = "1.8"
+zeroize = { version = "1.8", default-features = false }
 
 [dev-dependencies]
 benchmark-simple = "0.1.10"


### PR DESCRIPTION
Hello there,

The library currently fails to compile in `no_std` environments. I have added some feature gates to support this, without changing any of the underlying implementation.

I would appreciate it if you could help review this PR and consider publishing a point release.

Thank you.