### PR TITLE
[Informational] Arm optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["no-std", "cryptography", "wasm"]
 
 [features]
 default = ["std"]
-std = []
+std = ["zeroize/alloc"]
 
 [dependencies]
-zeroize = "1.8"
+zeroize = { version = "1.8", default-features = false }
 
 [dev-dependencies]
 benchmark-simple = "0.1.10"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    println!("cargo:rustc-check-cfg=cfg(thumb1, thumb2)");
+
+    if target.contains("thumbv7")
+        || target.contains("thumbv8m.main")
+        || target.contains("thumbv8r")
+        || target.contains("armv7")
+        || target.contains("armv8")
+        || target.contains("armv9")
+    {
+        println!("cargo:rustc-cfg=thumb2");
+    } else if target.contains("thumbv4")
+        || target.contains("thumbv5")
+        || target.contains("thumbv6")
+        || target.contains("thumbv8m.base")
+        || target.contains("armv4")
+        || target.contains("armv5")
+        || target.contains("armv6")
+    {
+        println!("cargo:rustc-cfg=thumb1");
+    }
+}

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -14,78 +14,233 @@ impl Xoodoo {
             asm!(
                 // Preserve callee-saved registers
                 "push {{r4-r7, lr}}",
-                "mov r0, r8", "mov r1, r9", "mov r2, r10", "mov r3, r11",
+                "mov  r0, r8",
+                "mov  r1, r9",
+                "mov  r2, r10",
+                "mov  r3, r11",
                 "push {{r0-r3}}",
-                "mov r0, r12", "push {{r0}}",
+                "mov  r0, r12",
+                "push {{r0}}",
 
                 // Stack frame: [0]=A03, [4]=rk, [8]=counter, [12]=st
-                "sub sp, sp, #16",
-                "str {rk}, [sp, #4]",
+                "sub  sp, sp, #16",
+                "str  {rk}, [sp, #4]",
                 "movs r0, #12",
-                "str r0, [sp, #8]",
-                "str {st}, [sp, #12]",
+                "str  r0, [sp, #8]",
+                "str  {st}, [sp, #12]",
 
                 // Load initial state
-                "mov r0, {st}",
-                "ldm r0!, {{r3, r4, r5, r6}}",
-                "mov r8, r4", "mov r9, r5", "str r6, [sp, #0]", // Row 0
-                "ldm r0!, {{r4, r5, r6, r7}}",
-                "mov r10, r4", "mov r11, r5", "mov r12, r6", "mov lr, r7", // Row 1
-                "ldm r0!, {{r4, r5, r6, r7}}", // Row 2 in r4..r7
+                "mov  r0, {st}",
+                "ldm  r0!, {{r3, r4, r5, r6}}",
+                "mov  r8, r4",
+                "mov  r9, r5",
+                "str  r6, [sp, #0]",                                // Row 0: A00..A03 in r3, r8, r9, [sp]
+                "ldm  r0!, {{r4, r5, r6, r7}}",
+                "mov  r10, r4",
+                "mov  r11, r5",
+                "mov  r12, r6",
+                "mov  lr, r7",                                      // Row 1: A10..A13 in r10, r11, r12, lr
+                "ldm  r0!, {{r4, r5, r6, r7}}",                     // Row 2: A20..A23 in r4, r5, r6, r7
 
                 ".p2align 2",
                 "0:", // Round loop
 
-                // === THETA ===
-                "ldr r0, [sp, #0]", "mov r1, lr", "eors r0, r0, r1", "eors r0, r0, r7", // P3
-                "mov r1, r0", "movs r2, #23", "rors r1, r1, r2", "eors r1, r1, r0", "movs r2, #27", "rors r1, r1, r2", // r1 = E0
-                "mov r0, r3", "mov r2, r10", "eors r0, r0, r2", "eors r0, r0, r4", // P0
-                "eors r3, r3, r1", "mov r2, r10", "eors r2, r2, r1", "mov r10, r2", "eors r4, r4, r1",
+                // === θ step ===
+                // P[x] = A[x,0] ^ A[x,1] ^ A[x,2]
+                // E[x] = rot(P[x-1], 5) ^ rot(P[x-1], 14)          (calculated as (P ^ rot(P, 9)).rot(5))
+                // A[x,y] = A[x,y] ^ E[x]
 
-                "mov r1, r0", "movs r2, #23", "rors r1, r1, r2", "eors r1, r1, r0", "movs r2, #27", "rors r1, r1, r2", // r1 = E1
-                "mov r0, r8", "mov r2, r11", "eors r0, r0, r2", "eors r0, r0, r5", // P1
-                "mov r2, r8", "eors r2, r2, r1", "mov r8, r2", "mov r2, r11", "eors r2, r2, r1", "mov r11, r2", "eors r5, r5, r1",
+                "ldr  r0, [sp, #0]",
+                "mov  r1, lr",
+                "eors r0, r0, r1",
+                "eors r0, r0, r7",                                  // r0 = P3
+                "mov  r1, r0",
+                "movs r2, #23",
+                "rors r1, r1, r2",
+                "eors r1, r1, r0",
+                "movs r2, #27",
+                "rors r1, r1, r2",                                  // r1 = E0
+                "mov  r0, r3",
+                "mov  r2, r10",
+                "eors r0, r0, r2",
+                "eors r0, r0, r4",                                  // r0 = P0
+                "eors r3, r3, r1",
+                "mov  r2, r10",
+                "eors r2, r2, r1",
+                "mov  r10, r2",
+                "eors r4, r4, r1",
 
-                "mov r1, r0", "movs r2, #23", "rors r1, r1, r2", "eors r1, r1, r0", "movs r2, #27", "rors r1, r1, r2", // r1 = E2
-                "mov r0, r9", "mov r2, r12", "eors r0, r0, r2", "eors r0, r0, r6", // P2
-                "mov r2, r9", "eors r2, r2, r1", "mov r9, r2", "mov r2, r12", "eors r2, r2, r1", "mov r12, r2", "eors r6, r6, r1",
+                "mov  r1, r0",
+                "movs r2, #23",
+                "rors r1, r1, r2",
+                "eors r1, r1, r0",
+                "movs r2, #27",
+                "rors r1, r1, r2",                                  // r1 = E1
+                "mov  r0, r8",
+                "mov  r2, r11",
+                "eors r0, r0, r2",
+                "eors r0, r0, r5",                                  // r0 = P1
+                "mov  r2, r8",
+                "eors r2, r2, r1",
+                "mov  r8, r2",
+                "mov  r2, r11",
+                "eors r2, r2, r1",
+                "mov  r11, r2",
+                "eors r5, r5, r1",
 
-                "mov r1, r0", "movs r2, #23", "rors r1, r1, r2", "eors r1, r1, r0", "movs r2, #27", "rors r1, r1, r2", // r1 = E3
-                "ldr r0, [sp, #0]", "eors r0, r0, r1", "str r0, [sp, #0]", "mov r2, lr", "eors r2, r2, r1", "mov lr, r2", "eors r7, r7, r1",
+                "mov  r1, r0",
+                "movs r2, #23",
+                "rors r1, r1, r2",
+                "eors r1, r1, r0",
+                "movs r2, #27",
+                "rors r1, r1, r2",                                  // r1 = E2
+                "mov  r0, r9",
+                "mov  r2, r12",
+                "eors r0, r0, r2",
+                "eors r0, r0, r6",                                  // r0 = P2
+                "mov  r2, r9",
+                "eors r2, r2, r1",
+                "mov  r9, r2",
+                "mov  r2, r12",
+                "eors r2, r2, r1",
+                "mov  r12, r2",
+                "eors r6, r6, r1",
 
-                // === RHO WEST ===
-                // Row 1 Column Shift (0<-3, 1<-0, 2<-1, 3<-2)
-                "mov r0, lr", "mov lr, r12", "mov r12, r11", "mov r11, r10", "mov r10, r0",
-                // Row 2 Bit Rotate (Left 11)
-                "movs r0, #21", "rors r4, r4, r0", "rors r5, r5, r0", "rors r6, r6, r0", "rors r7, r7, r0",
+                "mov  r1, r0",
+                "movs r2, #23",
+                "rors r1, r1, r2",
+                "eors r1, r1, r0",
+                "movs r2, #27",
+                "rors r1, r1, r2",                                  // r1 = E3
+                "ldr  r0, [sp, #0]",
+                "eors r0, r0, r1",
+                "str  r0, [sp, #0]",
+                "mov  r2, lr",
+                "eors r2, r2, r1",
+                "mov  lr, r2",
+                "eors r7, r7, r1",
 
-                // === IOTA ===
-                "ldr r0, [sp, #4]", "ldm r0!, {{r1}}", "str r0, [sp, #4]", "eors r3, r3, r1",
+                // === ρ West step ===
+                // A[x,1] = A[x-1,1]
+                // A[x,2] = rot(A[x,2], 11)
 
-                // === CHI ===
+                "mov  r0, lr",
+                "mov  lr, r12",
+                "mov  r12, r11",
+                "mov  r11, r10",
+                "mov  r10, r0",
+
+                "movs r0, #21",
+                "rors r4, r4, r0",
+                "rors r5, r5, r0",
+                "rors r6, r6, r0",
+                "rors r7, r7, r0",
+
+                // === ι step ===
+                // A[0,0] = A[0,0] ^ RC
+
+                "ldr  r0, [sp, #4]",
+                "ldm  r0!, {{r1}}",
+                "str  r0, [sp, #4]",
+                "eors r3, r3, r1",
+
+                // === χ step ===
+                // A[x,y] = A[x,y] ^ ((not A[x,y+1]) and A[x,y+2])
+                // Uses BIC(dest, src) -> dest = dest & ~src
+
                 // Col 0
-                "mov r0, r3", "mov r1, r10", "bics r2, r4, r1", "eors r3, r3, r2", "bics r2, r0, r4", "eors r10, r10, r2", "bics r2, r1, r0", "eors r4, r4, r2",
+                "mov  r0, r3",
+                "mov  r1, r10",
+                "bics r2, r4, r1",
+                "eors r3, r3, r2",
+                "bics r2, r0, r4",
+                "eors r10, r10, r2",
+                "bics r2, r1, r0",
+                "eors r4, r4, r2",
                 // Col 1
-                "mov r0, r8", "mov r1, r11", "bics r2, r5, r1", "eors r8, r8, r2", "bics r2, r0, r5", "eors r11, r11, r2", "bics r2, r1, r0", "eors r5, r5, r2",
+                "mov  r0, r8",
+                "mov  r1, r11",
+                "bics r2, r5, r1",
+                "eors r8, r8, r2",
+                "bics r2, r0, r5",
+                "eors r11, r11, r2",
+                "bics r2, r1, r0",
+                "eors r5, r5, r2",
                 // Col 2
-                "mov r0, r9", "mov r1, r12", "bics r2, r6, r1", "eors r9, r9, r2", "bics r2, r0, r6", "eors r12, r12, r2", "bics r2, r1, r0", "eors r6, r6, r2",
+                "mov  r0, r9",
+                "mov  r1, r12",
+                "bics r2, r6, r1",
+                "eors r9, r9, r2",
+                "bics r2, r0, r6",
+                "eors r12, r12, r2",
+                "bics r2, r1, r0",
+                "eors r6, r6, r2",
                 // Col 3
-                "ldr r0, [sp, #0]", "mov r1, lr", "bics r2, r7, r1", "eors r0, r0, r2", "str r0, [sp, #0]", "bics r2, r0, r7", "eors lr, lr, r2", "bics r2, r1, r0", "eors r7, r7, r2",
+                "ldr  r0, [sp, #0]",
+                "mov  r1, lr",
+                "bics r2, r7, r1",
+                "eors r0, r0, r2",
+                "str  r0, [sp, #0]",
+                "bics r2, r0, r7",
+                "eors lr, lr, r2",
+                "bics r2, r1, r0",
+                "eors r7, r7, r2",
 
-                // === RHO EAST ===
-                // Row 1 Bit Rotate (Left 1)
-                "movs r0, #31", "mov r1, r10", "rors r1, r1, r0", "mov r10, r1", "mov r1, r11", "rors r1, r1, r0", "mov r11, r1", "mov r1, r12", "rors r1, r1, r0", "mov r12, r1", "mov r1, lr", "rors r1, r1, r0", "mov lr, r1",
-                // Row 2 Bit Rotate (Left 8) and Column shift (x+2)
-                "movs r0, #24", "rors r4, r4, r0", "rors r5, r5, r0", "rors r6, r6, r0", "rors r7, r7, r0",
-                "mov r0, r4", "mov r4, r6", "mov r6, r0", "mov r0, r5", "mov r5, r7", "mov r7, r0",
+                // === ρ East step ===
+                // A[x,1] = rot(A[x,1], 1)
+                // A[x,2] = rot(A[x-2,2], 8)
 
-                "ldr r0, [sp, #8]", "subs r0, r0, #1", "str r0, [sp, #8]", "beq 1f", "b 0b", "1:",
+                "movs r0, #31",
+                "mov  r1, r10", "rors r1, r1, r0", "mov  r10, r1",
+                "mov  r1, r11", "rors r1, r1, r0", "mov  r11, r1",
+                "mov  r1, r12", "rors r1, r1, r0", "mov  r12, r1",
+                "mov  r1, lr",  "rors r1, r1, r0", "mov  lr, r1",
 
-                // Save back
-                "ldr r0, [sp, #12]", "stm r0!, {{r3}}", "mov r1, r8", "mov r2, r9", "ldr r3, [sp, #0]", "stm r0!, {{r1-r3}}", "mov r1, r10", "mov r2, r11", "mov r3, r12", "stm r0!, {{r1-r3}}", "mov r1, lr", "stm r0!, {{r1, r4-r7}}",
+                "movs r0, #24",
+                "rors r4, r4, r0",
+                "rors r5, r5, r0",
+                "rors r6, r6, r0",
+                "rors r7, r7, r0",
+                "mov  r0, r4",
+                "mov  r4, r6",
+                "mov  r6, r0",
+                "mov  r0, r5",
+                "mov  r5, r7",
+                "mov  r7, r0",
 
-                // Restore
-                "add sp, sp, #16", "pop {{r0}}", "mov r12, r0", "pop {{r0-r3}}", "mov r8, r0", "mov r9, r1", "mov r10, r2", "mov r11, r3", "pop {{r4-r7}}", "pop {{r0}}", "mov lr, r0",
+                "ldr  r0, [sp, #8]",
+                "subs r0, r0, #1",
+                "str  r0, [sp, #8]",
+                "beq  1f",
+                "b    0b",
+                "1:",
+
+                // Save back state
+                "ldr  r0, [sp, #12]",
+                "stm  r0!, {{r3}}",
+                "mov  r1, r8",
+                "mov  r2, r9",
+                "ldr  r3, [sp, #0]",
+                "stm  r0!, {{r1-r3}}",
+                "mov  r1, r10",
+                "mov  r2, r11",
+                "mov  r3, r12",
+                "stm  r0!, {{r1-r3}}",
+                "mov  r1, lr",
+                "stm  r0!, {{r1, r4-r7}}",
+
+                // Restore registers
+                "add  sp, sp, #16",
+                "pop  {{r0}}",
+                "mov  r12, r0",
+                "pop  {{r0-r3}}",
+                "mov  r8, r0",
+                "mov  r9, r1",
+                "mov  r10, r2",
+                "mov  r11, r3",
+                "pop  {{r4-r7}}",
+                "pop  {{r0}}",
+                "mov  lr, r0",
 
                 rk = in(reg) rkeys,
                 st = in(reg) st_ptr,

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -55,84 +55,84 @@ impl Xoodoo {
                 // P3 = A[3,0] ^ A[3,1] ^ A[3,2]
                 "ldr     r0, [sp, #0]",
                 "mov     r1, lr",
-                "eors    r0, r0, r1",
-                "eors    r0, r0, r7",               // r0 = P3
+                "eors    r0, r1",
+                "eors    r0, r7",                   // r0 = P3
                 "mov     r1, r0",
                 "movs    r2, #23",                  // rot 9
-                "rors    r1, r1, r2",
-                "eors    r1, r1, r0",
+                "rors    r1, r2",
+                "eors    r1, r0",
                 "movs    r2, #27",                  // rot 5
-                "rors    r1, r1, r2",               // r1 = E0
+                "rors    r1, r2",                   // r1 = E0
 
                 // Apply E0 to Col 0
                 "mov     r0, r3",                   // P0 calculation starts here
                 "mov     r2, r10",
-                "eors    r0, r0, r2",
-                "eors    r0, r0, r4",               // r0 = P0
-                "eors    r3, r3, r1",               // A[0,0] ^= E0
+                "eors    r0, r2",
+                "eors    r0, r4",                   // r0 = P0
+                "eors    r3, r1",                   // A[0,0] ^= E0
                 "mov     r2, r10",
-                "eors    r2, r2, r1",
+                "eors    r2, r1",
                 "mov     r10, r2",                  // A[0,1] ^= E0
-                "eors    r4, r4, r1",               // A[0,2] ^= E0
+                "eors    r4, r1",                   // A[0,2] ^= E0
 
                 // --- Calculate E1 from P0 ---
                 "mov     r1, r0",
                 "movs    r2, #23",
-                "rors    r1, r1, r2",
-                "eors    r1, r1, r0",
+                "rors    r1, r2",
+                "eors    r1, r0",
                 "movs    r2, #27",
-                "rors    r1, r1, r2",               // r1 = E1
+                "rors    r1, r2",               // r1 = E1
 
                 // Apply E1 to Col 1
                 "mov     r0, r8",                   // P1 calculation
                 "mov     r2, r11",
-                "eors    r0, r0, r2",
-                "eors    r0, r0, r5",               // r0 = P1
+                "eors    r0, r2",
+                "eors    r0, r5",               // r0 = P1
                 "mov     r2, r8",
-                "eors    r2, r2, r1",
+                "eors    r2, r1",
                 "mov     r8, r2",                   // A[1,0] ^= E1
                 "mov     r2, r11",
-                "eors    r2, r2, r1",
+                "eors    r2, r1",
                 "mov     r11, r2",                  // A[1,1] ^= E1
-                "eors    r5, r5, r1",               // A[1,2] ^= E1
+                "eors    r5, r1",                   // A[1,2] ^= E1
 
                 // --- Calculate E2 from P1 ---
                 "mov     r1, r0",
                 "movs    r2, #23",
-                "rors    r1, r1, r2",
-                "eors    r1, r1, r0",
+                "rors    r1, r2",
+                "eors    r1, r0",
                 "movs    r2, #27",
-                "rors    r1, r1, r2",               // r1 = E2
+                "rors    r1, r2",               // r1 = E2
 
                 // Apply E2 to Col 2
                 "mov     r0, r9",                   // P2 calculation
                 "mov     r2, r12",
-                "eors    r0, r0, r2",
-                "eors    r0, r0, r6",               // r0 = P2
+                "eors    r0, r2",
+                "eors    r0, r6",               // r0 = P2
                 "mov     r2, r9",
-                "eors    r2, r2, r1",
+                "eors    r2, r1",
                 "mov     r9, r2",                   // A[2,0] ^= E2
                 "mov     r2, r12",
-                "eors    r2, r2, r1",
+                "eors    r2, r1",
                 "mov     r12, r2",                  // A[2,1] ^= E2
-                "eors    r6, r6, r1",               // A[2,2] ^= E2
+                "eors    r6, r1",                   // A[2,2] ^= E2
 
                 // --- Calculate E3 from P2 ---
                 "mov     r1, r0",
                 "movs    r2, #23",
-                "rors    r1, r1, r2",
-                "eors    r1, r1, r0",
+                "rors    r1, r2",
+                "eors    r1, r0",
                 "movs    r2, #27",
-                "rors    r1, r1, r2",               // r1 = E3
+                "rors    r1, r2",               // r1 = E3
 
                 // Apply E3 to Col 3
                 "ldr     r0, [sp, #0]",
-                "eors    r0, r0, r1",
+                "eors    r0, r1",
                 "str     r0, [sp, #0]",             // A[3,0] ^= E3
                 "mov     r2, lr",
-                "eors    r2, r2, r1",
+                "eors    r2, r1",
                 "mov     lr, r2",                   // A[3,1] ^= E3
-                "eors    r7, r7, r1",               // A[3,2] ^= E3
+                "eors    r7, r1",                   // A[3,2] ^= E3
 
                 // === ρ (Rho) West step ===
                 // A[x,1] = A[x-1,1] (Cyclic shift Row 1)
@@ -144,17 +144,17 @@ impl Xoodoo {
 
                 // A[x,2] = rot(A[x,2], 11)
                 "movs    r0, #21",                  // rot 11
-                "rors    r4, r4, r0",
-                "rors    r5, r5, r0",
-                "rors    r6, r6, r0",
-                "rors    r7, r7, r0",
+                "rors    r4, r0",
+                "rors    r5, r0",
+                "rors    r6, r0",
+                "rors    r7, r0",
 
                 // === ι (Iota) step ===
                 // A[0,0] ^= RC
                 "ldr     r0, [sp, #4]",
                 "ldm     r0!, {{r1}}",
                 "str     r0, [sp, #4]",
-                "eors    r3, r3, r1",
+                "eors    r3, r1",
 
                 // === χ (Chi) step ===
                 // A[x,y] ^= (~A[x,y+1]) & A[x,y+2]
@@ -162,46 +162,76 @@ impl Xoodoo {
                 // x=0 (Col 0)
                 "mov     r0, r3",
                 "mov     r1, r10",
-                "bics    r2, r4, r1",   "eors r3, r3, r2",
-                "bics    r2, r0, r4",   "eors r10, r10, r2",
-                "bics    r2, r1, r0",   "eors r4, r4, r2",
+                "mov     r2, r4",
+                "bics    r2, r1",
+                "eors    r3, r2",
+                "mov     r2, r0",
+                "bics    r2, r4",
+                "eors    r2, r1",
+                "mov     r10, r2",
+                "mov     r2, r1",
+                "bics    r2, r0",
+                "eors    r4, r2",
 
                 // x=1 (Col 1)
                 "mov     r0, r8",
                 "mov     r1, r11",
-                "bics    r2, r5, r1",   "eors r8, r8, r2",
-                "bics    r2, r0, r5",   "eors r11, r11, r2",
-                "bics    r2, r1, r0",   "eors r5, r5, r2",
+                "mov     r2, r5",
+                "bics    r2, r1",
+                "eors    r2, r0",
+                "mov     r8, r2",
+                "mov     r2, r0",
+                "bics    r2, r5",
+                "eors    r2, r1",
+                "mov     r11, r2",
+                "mov     r2, r1",
+                "bics    r2, r0",
+                "eors    r5, r2",
 
                 // x=2 (Col 2)
                 "mov     r0, r9",
                 "mov     r1, r12",
-                "bics    r2, r6, r1",   "eors r9, r9, r2",
-                "bics    r2, r0, r6",   "eors r12, r12, r2",
-                "bics    r2, r1, r0",   "eors r6, r6, r2",
+                "mov     r2, r6",
+                "bics    r2, r1",
+                "eors    r2, r0",
+                "mov     r9, r2",
+                "mov     r2, r0",
+                "bics    r2, r6",
+                "eors    r2, r1",
+                "mov     r12, r2",
+                "mov     r2, r1",
+                "bics    r2, r0",
+                "eors    r6, r2",
 
                 // x=3 (Col 3)
                 "ldr     r0, [sp, #0]",
                 "mov     r1, lr",
-                "bics    r2, r7, r1",   "eors r0, r0, r2",
+                "mov     r2, r7",
+                "bics    r2, r1",
+                "eors    r0, r2",
                 "str     r0, [sp, #0]",
-                "bics    r2, r0, r7",   "eors lr, lr, r2",
-                "bics    r2, r1, r0",   "eors r7, r7, r2",
+                "mov     r2, r0",
+                "bics    r2, r7",
+                "eors    r2, r1",
+                "mov     lr, r2",
+                "mov     r2, r1",
+                "bics    r2, r0",
+                "eors    r7, r2",
 
                 // === ρ (Rho) East step ===
                 // A[x,1] = rot(A[x,1], 1)
                 "movs    r0, #31",                  // rot 1
-                "mov     r1, r10",  "rors r1, r1, r0",  "mov r10, r1",
-                "mov     r1, r11",  "rors r1, r1, r0",  "mov r11, r1",
-                "mov     r1, r12",  "rors r1, r1, r0",  "mov r12, r1",
-                "mov     r1, lr",   "rors r1, r1, r0",  "mov lr, r1",
+                "mov     r1, r10",  "rors r1, r0",  "mov r10, r1",
+                "mov     r1, r11",  "rors r1, r0",  "mov r11, r1",
+                "mov     r1, r12",  "rors r1, r0",  "mov r12, r1",
+                "mov     r1, lr",   "rors r1, r0",  "mov lr, r1",
 
                 // A[x,2] = rot(A[x-2,2], 8)
                 "movs    r0, #24",                  // rot 8
-                "rors    r4, r4, r0",
-                "rors    r5, r5, r0",
-                "rors    r6, r6, r0",
-                "rors    r7, r7, r0",
+                "rors    r4, r0",
+                "rors    r5, r0",
+                "rors    r6, r0",
+                "rors    r7, r0",
                 // Cyclic shift Row 2 by 2
                 "mov     r0, r4",   "mov r4, r6",   "mov r6, r0",
                 "mov     r0, r5",   "mov r5, r7",   "mov r7, r0",

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -22,11 +22,12 @@ impl Xoodoo {
                 "push    {{r0}}",
 
                 // Stack frame: [0]=A30, [4]=rk, [8]=counter, [12]=st
-                "sub     sp, sp, #16",
-                "str     {rk}, [sp, #4]",
+                "push    {{{st}}}",                 // [sp, #12]:st
                 "movs    r0, #12",
-                "str     r0, [sp, #8]",
-                "str     {st}, [sp, #12]",
+                "push    {{r0}}",                    // [sp, #8]:counter
+                "push    {{{rk}}}",                  // [sp, #4]:rk
+                "movs    r0, #0",
+                "push    {{r0}}",                    // [sp, #0]:A30 placeholder
 
                 // Load initial state
                 // Row 0: r3, r8, r9, [sp, #0]   (A[0,0], A[1,0], A[2,0], A[3,0])
@@ -254,7 +255,7 @@ impl Xoodoo {
                 "stm     r0!, {{r1, r4-r7}}",
 
                 // Restore registers
-                "add     sp, sp, #16",
+                "pop     {{r0, r1, r2, r3}}",               // Discard frame
                 "pop     {{r0}}",
                 "mov     r12, r0",
                 "pop     {{r0-r3}}",

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -1,7 +1,6 @@
-#![cfg(all(target_arch = "arm", not(target_has_atomic = "32")))]
+use core::arch::asm;
 
 use super::{Xoodoo, ROUND_KEYS};
-use core::arch::asm;
 
 impl Xoodoo {
     /// Optimized Xoodoo permutation for ARMv6-M (Cortex-M0).

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -1,8 +1,8 @@
+#![cfg(all(target_arch = "arm", not(target_has_atomic = "32")))]
+
 use super::{Xoodoo, ROUND_KEYS};
-#[cfg(all(target_arch = "arm", not(target_has_atomic = "32")))]
 use core::arch::asm;
 
-#[cfg(all(target_arch = "arm", not(target_has_atomic = "32")))]
 impl Xoodoo {
     /// Optimized Xoodoo permutation for ARMv6-M (Cortex-M0).
     #[allow(clippy::many_single_char_names)]

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -1,0 +1,96 @@
+use super::{Xoodoo, ROUND_KEYS};
+#[cfg(all(target_arch = "arm", not(target_has_atomic = "32")))]
+use core::arch::asm;
+
+#[cfg(all(target_arch = "arm", not(target_has_atomic = "32")))]
+impl Xoodoo {
+    /// Optimized Xoodoo permutation for ARMv6-M (Cortex-M0).
+    #[allow(clippy::many_single_char_names)]
+    pub fn permute(&mut self) {
+        let rkeys = ROUND_KEYS.as_ptr();
+        unsafe {
+            let st_ptr = self.st.as_mut_ptr() as *mut u32;
+
+            asm!(
+                // Preserve callee-saved registers
+                "push {{r4-r7, lr}}",
+                "mov r0, r8", "mov r1, r9", "mov r2, r10", "mov r3, r11",
+                "push {{r0-r3}}",
+                "mov r0, r12", "push {{r0}}",
+
+                // Stack frame: [0]=A03, [4]=rk, [8]=counter, [12]=st
+                "sub sp, sp, #16",
+                "str {rk}, [sp, #4]",
+                "movs r0, #12",
+                "str r0, [sp, #8]",
+                "str {st}, [sp, #12]",
+
+                // Load initial state
+                "mov r0, {st}",
+                "ldm r0!, {{r3, r4, r5, r6}}",
+                "mov r8, r4", "mov r9, r5", "str r6, [sp, #0]", // Row 0
+                "ldm r0!, {{r4, r5, r6, r7}}",
+                "mov r10, r4", "mov r11, r5", "mov r12, r6", "mov lr, r7", // Row 1
+                "ldm r0!, {{r4, r5, r6, r7}}", // Row 2 in r4..r7
+
+                ".p2align 2",
+                "0:", // Round loop
+
+                // === THETA ===
+                "ldr r0, [sp, #0]", "mov r1, lr", "eors r0, r0, r1", "eors r0, r0, r7", // P3
+                "mov r1, r0", "movs r2, #23", "rors r1, r1, r2", "eors r1, r1, r0", "movs r2, #27", "rors r1, r1, r2", // r1 = E0
+                "mov r0, r3", "mov r2, r10", "eors r0, r0, r2", "eors r0, r0, r4", // P0
+                "eors r3, r3, r1", "mov r2, r10", "eors r2, r2, r1", "mov r10, r2", "eors r4, r4, r1",
+
+                "mov r1, r0", "movs r2, #23", "rors r1, r1, r2", "eors r1, r1, r0", "movs r2, #27", "rors r1, r1, r2", // r1 = E1
+                "mov r0, r8", "mov r2, r11", "eors r0, r0, r2", "eors r0, r0, r5", // P1
+                "mov r2, r8", "eors r2, r2, r1", "mov r8, r2", "mov r2, r11", "eors r2, r2, r1", "mov r11, r2", "eors r5, r5, r1",
+
+                "mov r1, r0", "movs r2, #23", "rors r1, r1, r2", "eors r1, r1, r0", "movs r2, #27", "rors r1, r1, r2", // r1 = E2
+                "mov r0, r9", "mov r2, r12", "eors r0, r0, r2", "eors r0, r0, r6", // P2
+                "mov r2, r9", "eors r2, r2, r1", "mov r9, r2", "mov r2, r12", "eors r2, r2, r1", "mov r12, r2", "eors r6, r6, r1",
+
+                "mov r1, r0", "movs r2, #23", "rors r1, r1, r2", "eors r1, r1, r0", "movs r2, #27", "rors r1, r1, r2", // r1 = E3
+                "ldr r0, [sp, #0]", "eors r0, r0, r1", "str r0, [sp, #0]", "mov r2, lr", "eors r2, r2, r1", "mov lr, r2", "eors r7, r7, r1",
+
+                // === RHO WEST ===
+                // Row 1 Column Shift (0<-3, 1<-0, 2<-1, 3<-2)
+                "mov r0, lr", "mov lr, r12", "mov r12, r11", "mov r11, r10", "mov r10, r0",
+                // Row 2 Bit Rotate (Left 11)
+                "movs r0, #21", "rors r4, r4, r0", "rors r5, r5, r0", "rors r6, r6, r0", "rors r7, r7, r0",
+
+                // === IOTA ===
+                "ldr r0, [sp, #4]", "ldm r0!, {{r1}}", "str r0, [sp, #4]", "eors r3, r3, r1",
+
+                // === CHI ===
+                // Col 0
+                "mov r0, r3", "mov r1, r10", "bics r2, r4, r1", "eors r3, r3, r2", "bics r2, r0, r4", "eors r10, r10, r2", "bics r2, r1, r0", "eors r4, r4, r2",
+                // Col 1
+                "mov r0, r8", "mov r1, r11", "bics r2, r5, r1", "eors r8, r8, r2", "bics r2, r0, r5", "eors r11, r11, r2", "bics r2, r1, r0", "eors r5, r5, r2",
+                // Col 2
+                "mov r0, r9", "mov r1, r12", "bics r2, r6, r1", "eors r9, r9, r2", "bics r2, r0, r6", "eors r12, r12, r2", "bics r2, r1, r0", "eors r6, r6, r2",
+                // Col 3
+                "ldr r0, [sp, #0]", "mov r1, lr", "bics r2, r7, r1", "eors r0, r0, r2", "str r0, [sp, #0]", "bics r2, r0, r7", "eors lr, lr, r2", "bics r2, r1, r0", "eors r7, r7, r2",
+
+                // === RHO EAST ===
+                // Row 1 Bit Rotate (Left 1)
+                "movs r0, #31", "mov r1, r10", "rors r1, r1, r0", "mov r10, r1", "mov r1, r11", "rors r1, r1, r0", "mov r11, r1", "mov r1, r12", "rors r1, r1, r0", "mov r12, r1", "mov r1, lr", "rors r1, r1, r0", "mov lr, r1",
+                // Row 2 Bit Rotate (Left 8) and Column shift (x+2)
+                "movs r0, #24", "rors r4, r4, r0", "rors r5, r5, r0", "rors r6, r6, r0", "rors r7, r7, r0",
+                "mov r0, r4", "mov r4, r6", "mov r6, r0", "mov r0, r5", "mov r5, r7", "mov r7, r0",
+
+                "ldr r0, [sp, #8]", "subs r0, r0, #1", "str r0, [sp, #8]", "beq 1f", "b 0b", "1:",
+
+                // Save back
+                "ldr r0, [sp, #12]", "stm r0!, {{r3}}", "mov r1, r8", "mov r2, r9", "ldr r3, [sp, #0]", "stm r0!, {{r1-r3}}", "mov r1, r10", "mov r2, r11", "mov r3, r12", "stm r0!, {{r1-r3}}", "mov r1, lr", "stm r0!, {{r1, r4-r7}}",
+
+                // Restore
+                "add sp, sp, #16", "pop {{r0}}", "mov r12, r0", "pop {{r0-r3}}", "mov r8, r0", "mov r9, r1", "mov r10, r2", "mov r11, r3", "pop {{r4-r7}}", "pop {{r0}}", "mov lr, r0",
+
+                rk = in(reg) rkeys,
+                st = in(reg) st_ptr,
+                out("r0") _, out("r1") _, out("r2") _, out("r3") _,
+            );
+        }
+    }
+}

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -157,51 +157,45 @@ impl Xoodoo {
                 "eors    r3, r1",
 
                 // === χ (Chi) step ===
-                // A[x,y] ^= (~A[x,y+1]) & A[x,y+2]
+                // A[x,0] ^= (~A[x,1]) & A[x,2]
+                // A[x,1] ^= (~A[x,2]) & A[x,0]
+                // A[x,2] ^= (~A[x,0]) & A[x,1]
 
                 // x=0 (Col 0)
-                "mov     r0, r3",
                 "mov     r1, r10",
                 "mov     r2, r4",
                 "bics    r2, r1",
-                "eors    r3, r2",
-                "mov     r2, r0",
+                "eors    r3, r2",                   // a0 = a0_new
+                "mov     r2, r3",
                 "bics    r2, r4",
                 "eors    r2, r1",
-                "mov     r10, r2",
-                "mov     r2, r1",
-                "bics    r2, r0",
-                "eors    r4, r2",
+                "mov     r10, r2",                  // a1 = a1_new
+                "bics    r2, r3",
+                "eors    r4, r2",                   // a2 = a2_new
 
                 // x=1 (Col 1)
-                "mov     r0, r8",
                 "mov     r1, r11",
                 "mov     r2, r5",
                 "bics    r2, r1",
-                "eors    r2, r0",
-                "mov     r8, r2",
-                "mov     r2, r0",
+                "eors    r2, r8",
+                "mov     r8, r2",                   // a0 = a0_new
                 "bics    r2, r5",
                 "eors    r2, r1",
-                "mov     r11, r2",
-                "mov     r2, r1",
-                "bics    r2, r0",
-                "eors    r5, r2",
+                "mov     r11, r2",                  // a1 = a1_new
+                "bics    r2, r8",
+                "eors    r5, r2",                   // a2 = a2_new
 
                 // x=2 (Col 2)
-                "mov     r0, r9",
                 "mov     r1, r12",
                 "mov     r2, r6",
                 "bics    r2, r1",
-                "eors    r2, r0",
-                "mov     r9, r2",
-                "mov     r2, r0",
+                "eors    r2, r9",
+                "mov     r9, r2",                   // a0 = a0_new
                 "bics    r2, r6",
                 "eors    r2, r1",
-                "mov     r12, r2",
-                "mov     r2, r1",
-                "bics    r2, r0",
-                "eors    r6, r2",
+                "mov     r12, r2",                  // a1 = a1_new
+                "bics    r2, r9",
+                "eors    r6, r2",                   // a2 = a2_new
 
                 // x=3 (Col 3)
                 "ldr     r0, [sp, #0]",
@@ -209,14 +203,13 @@ impl Xoodoo {
                 "mov     r2, r7",
                 "bics    r2, r1",
                 "eors    r0, r2",
-                "str     r0, [sp, #0]",
+                "str     r0, [sp, #0]",             // a0 = a0_new
                 "mov     r2, r0",
                 "bics    r2, r7",
                 "eors    r2, r1",
-                "mov     lr, r2",
-                "mov     r2, r1",
+                "mov     lr, r2",                   // a1 = a1_new
                 "bics    r2, r0",
-                "eors    r7, r2",
+                "eors    r7, r2",                   // a2 = a2_new
 
                 // === ρ (Rho) East step ===
                 // A[x,1] = rot(A[x,1], 1)

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -13,234 +13,232 @@ impl Xoodoo {
 
             asm!(
                 // Preserve callee-saved registers
-                "push {{r4-r7, lr}}",
-                "mov  r0, r8",
-                "mov  r1, r9",
-                "mov  r2, r10",
-                "mov  r3, r11",
-                "push {{r0-r3}}",
-                "mov  r0, r12",
-                "push {{r0}}",
+                "push    {{r4-r7, lr}}",
+                "mov     r0, r8",
+                "mov     r1, r9",
+                "mov     r2, r10",
+                "mov     r3, r11",
+                "push    {{r0-r3}}",
+                "mov     r0, r12",
+                "push    {{r0}}",
 
-                // Stack frame: [0]=A03, [4]=rk, [8]=counter, [12]=st
-                "sub  sp, sp, #16",
-                "str  {rk}, [sp, #4]",
-                "movs r0, #12",
-                "str  r0, [sp, #8]",
-                "str  {st}, [sp, #12]",
+                // Stack frame: [0]=A30, [4]=rk, [8]=counter, [12]=st
+                "sub     sp, sp, #16",
+                "str     {rk}, [sp, #4]",
+                "movs    r0, #12",
+                "str     r0, [sp, #8]",
+                "str     {st}, [sp, #12]",
 
                 // Load initial state
-                "mov  r0, {st}",
-                "ldm  r0!, {{r3, r4, r5, r6}}",
-                "mov  r8, r4",
-                "mov  r9, r5",
-                "str  r6, [sp, #0]",                                // Row 0: A00..A03 in r3, r8, r9, [sp]
-                "ldm  r0!, {{r4, r5, r6, r7}}",
-                "mov  r10, r4",
-                "mov  r11, r5",
-                "mov  r12, r6",
-                "mov  lr, r7",                                      // Row 1: A10..A13 in r10, r11, r12, lr
-                "ldm  r0!, {{r4, r5, r6, r7}}",                     // Row 2: A20..A23 in r4, r5, r6, r7
+                // Row 0: r3, r8, r9, [sp, #0]   (A[0,0], A[1,0], A[2,0], A[3,0])
+                // Row 1: r10, r11, r12, lr     (A[0,1], A[1,1], A[2,1], A[3,1])
+                // Row 2: r4, r5, r6, r7        (A[0,2], A[1,2], A[2,2], A[3,2])
+                "mov     r0, {st}",
+                "ldm     r0!, {{r3, r4, r5, r6}}",
+                "mov     r8, r4",
+                "mov     r9, r5",
+                "str     r6, [sp, #0]",
+                "ldm     r0!, {{r4, r5, r6, r7}}",
+                "mov     r10, r4",
+                "mov     r11, r5",
+                "mov     r12, r6",
+                "mov     lr, r7",
+                "ldm     r0!, {{r4, r5, r6, r7}}",
 
                 ".p2align 2",
-                "0:", // Round loop
+                "0:",
 
-                // === θ step ===
+                // === θ (Theta) step ===
                 // P[x] = A[x,0] ^ A[x,1] ^ A[x,2]
-                // E[x] = rot(P[x-1], 5) ^ rot(P[x-1], 14)          (calculated as (P ^ rot(P, 9)).rot(5))
-                // A[x,y] = A[x,y] ^ E[x]
+                // E[x] = rot(P[x-1], 5) ^ rot(P[x-1], 14)
 
-                "ldr  r0, [sp, #0]",
-                "mov  r1, lr",
-                "eors r0, r0, r1",
-                "eors r0, r0, r7",                                  // r0 = P3
-                "mov  r1, r0",
-                "movs r2, #23",
-                "rors r1, r1, r2",
-                "eors r1, r1, r0",
-                "movs r2, #27",
-                "rors r1, r1, r2",                                  // r1 = E0
-                "mov  r0, r3",
-                "mov  r2, r10",
-                "eors r0, r0, r2",
-                "eors r0, r0, r4",                                  // r0 = P0
-                "eors r3, r3, r1",
-                "mov  r2, r10",
-                "eors r2, r2, r1",
-                "mov  r10, r2",
-                "eors r4, r4, r1",
+                // --- Calculate E0 from P3 ---
+                // P3 = A[3,0] ^ A[3,1] ^ A[3,2]
+                "ldr     r0, [sp, #0]",
+                "mov     r1, lr",
+                "eors    r0, r0, r1",
+                "eors    r0, r0, r7",               // r0 = P3
+                "mov     r1, r0",
+                "movs    r2, #23",                  // rot 9
+                "rors    r1, r1, r2",
+                "eors    r1, r1, r0",
+                "movs    r2, #27",                  // rot 5
+                "rors    r1, r1, r2",               // r1 = E0
 
-                "mov  r1, r0",
-                "movs r2, #23",
-                "rors r1, r1, r2",
-                "eors r1, r1, r0",
-                "movs r2, #27",
-                "rors r1, r1, r2",                                  // r1 = E1
-                "mov  r0, r8",
-                "mov  r2, r11",
-                "eors r0, r0, r2",
-                "eors r0, r0, r5",                                  // r0 = P1
-                "mov  r2, r8",
-                "eors r2, r2, r1",
-                "mov  r8, r2",
-                "mov  r2, r11",
-                "eors r2, r2, r1",
-                "mov  r11, r2",
-                "eors r5, r5, r1",
+                // Apply E0 to Col 0
+                "mov     r0, r3",                   // P0 calculation starts here
+                "mov     r2, r10",
+                "eors    r0, r0, r2",
+                "eors    r0, r0, r4",               // r0 = P0
+                "eors    r3, r3, r1",               // A[0,0] ^= E0
+                "mov     r2, r10",
+                "eors    r2, r2, r1",
+                "mov     r10, r2",                  // A[0,1] ^= E0
+                "eors    r4, r4, r1",               // A[0,2] ^= E0
 
-                "mov  r1, r0",
-                "movs r2, #23",
-                "rors r1, r1, r2",
-                "eors r1, r1, r0",
-                "movs r2, #27",
-                "rors r1, r1, r2",                                  // r1 = E2
-                "mov  r0, r9",
-                "mov  r2, r12",
-                "eors r0, r0, r2",
-                "eors r0, r0, r6",                                  // r0 = P2
-                "mov  r2, r9",
-                "eors r2, r2, r1",
-                "mov  r9, r2",
-                "mov  r2, r12",
-                "eors r2, r2, r1",
-                "mov  r12, r2",
-                "eors r6, r6, r1",
+                // --- Calculate E1 from P0 ---
+                "mov     r1, r0",
+                "movs    r2, #23",
+                "rors    r1, r1, r2",
+                "eors    r1, r1, r0",
+                "movs    r2, #27",
+                "rors    r1, r1, r2",               // r1 = E1
 
-                "mov  r1, r0",
-                "movs r2, #23",
-                "rors r1, r1, r2",
-                "eors r1, r1, r0",
-                "movs r2, #27",
-                "rors r1, r1, r2",                                  // r1 = E3
-                "ldr  r0, [sp, #0]",
-                "eors r0, r0, r1",
-                "str  r0, [sp, #0]",
-                "mov  r2, lr",
-                "eors r2, r2, r1",
-                "mov  lr, r2",
-                "eors r7, r7, r1",
+                // Apply E1 to Col 1
+                "mov     r0, r8",                   // P1 calculation
+                "mov     r2, r11",
+                "eors    r0, r0, r2",
+                "eors    r0, r0, r5",               // r0 = P1
+                "mov     r2, r8",
+                "eors    r2, r2, r1",
+                "mov     r8, r2",                   // A[1,0] ^= E1
+                "mov     r2, r11",
+                "eors    r2, r2, r1",
+                "mov     r11, r2",                  // A[1,1] ^= E1
+                "eors    r5, r5, r1",               // A[1,2] ^= E1
 
-                // === ρ West step ===
-                // A[x,1] = A[x-1,1]
+                // --- Calculate E2 from P1 ---
+                "mov     r1, r0",
+                "movs    r2, #23",
+                "rors    r1, r1, r2",
+                "eors    r1, r1, r0",
+                "movs    r2, #27",
+                "rors    r1, r1, r2",               // r1 = E2
+
+                // Apply E2 to Col 2
+                "mov     r0, r9",                   // P2 calculation
+                "mov     r2, r12",
+                "eors    r0, r0, r2",
+                "eors    r0, r0, r6",               // r0 = P2
+                "mov     r2, r9",
+                "eors    r2, r2, r1",
+                "mov     r9, r2",                   // A[2,0] ^= E2
+                "mov     r2, r12",
+                "eors    r2, r2, r1",
+                "mov     r12, r2",                  // A[2,1] ^= E2
+                "eors    r6, r6, r1",               // A[2,2] ^= E2
+
+                // --- Calculate E3 from P2 ---
+                "mov     r1, r0",
+                "movs    r2, #23",
+                "rors    r1, r1, r2",
+                "eors    r1, r1, r0",
+                "movs    r2, #27",
+                "rors    r1, r1, r2",               // r1 = E3
+
+                // Apply E3 to Col 3
+                "ldr     r0, [sp, #0]",
+                "eors    r0, r0, r1",
+                "str     r0, [sp, #0]",             // A[3,0] ^= E3
+                "mov     r2, lr",
+                "eors    r2, r2, r1",
+                "mov     lr, r2",                   // A[3,1] ^= E3
+                "eors    r7, r7, r1",               // A[3,2] ^= E3
+
+                // === ρ (Rho) West step ===
+                // A[x,1] = A[x-1,1] (Cyclic shift Row 1)
+                "mov     r0, lr",
+                "mov     lr, r12",
+                "mov     r12, r11",
+                "mov     r11, r10",
+                "mov     r10, r0",
+
                 // A[x,2] = rot(A[x,2], 11)
+                "movs    r0, #21",                  // rot 11
+                "rors    r4, r4, r0",
+                "rors    r5, r5, r0",
+                "rors    r6, r6, r0",
+                "rors    r7, r7, r0",
 
-                "mov  r0, lr",
-                "mov  lr, r12",
-                "mov  r12, r11",
-                "mov  r11, r10",
-                "mov  r10, r0",
+                // === ι (Iota) step ===
+                // A[0,0] ^= RC
+                "ldr     r0, [sp, #4]",
+                "ldm     r0!, {{r1}}",
+                "str     r0, [sp, #4]",
+                "eors    r3, r3, r1",
 
-                "movs r0, #21",
-                "rors r4, r4, r0",
-                "rors r5, r5, r0",
-                "rors r6, r6, r0",
-                "rors r7, r7, r0",
+                // === χ (Chi) step ===
+                // A[x,y] ^= (~A[x,y+1]) & A[x,y+2]
 
-                // === ι step ===
-                // A[0,0] = A[0,0] ^ RC
+                // x=0 (Col 0)
+                "mov     r0, r3",
+                "mov     r1, r10",
+                "bics    r2, r4, r1",   "eors r3, r3, r2",
+                "bics    r2, r0, r4",   "eors r10, r10, r2",
+                "bics    r2, r1, r0",   "eors r4, r4, r2",
 
-                "ldr  r0, [sp, #4]",
-                "ldm  r0!, {{r1}}",
-                "str  r0, [sp, #4]",
-                "eors r3, r3, r1",
+                // x=1 (Col 1)
+                "mov     r0, r8",
+                "mov     r1, r11",
+                "bics    r2, r5, r1",   "eors r8, r8, r2",
+                "bics    r2, r0, r5",   "eors r11, r11, r2",
+                "bics    r2, r1, r0",   "eors r5, r5, r2",
 
-                // === χ step ===
-                // A[x,y] = A[x,y] ^ ((not A[x,y+1]) and A[x,y+2])
-                // Uses BIC(dest, src) -> dest = dest & ~src
+                // x=2 (Col 2)
+                "mov     r0, r9",
+                "mov     r1, r12",
+                "bics    r2, r6, r1",   "eors r9, r9, r2",
+                "bics    r2, r0, r6",   "eors r12, r12, r2",
+                "bics    r2, r1, r0",   "eors r6, r6, r2",
 
-                // Col 0
-                "mov  r0, r3",
-                "mov  r1, r10",
-                "bics r2, r4, r1",
-                "eors r3, r3, r2",
-                "bics r2, r0, r4",
-                "eors r10, r10, r2",
-                "bics r2, r1, r0",
-                "eors r4, r4, r2",
-                // Col 1
-                "mov  r0, r8",
-                "mov  r1, r11",
-                "bics r2, r5, r1",
-                "eors r8, r8, r2",
-                "bics r2, r0, r5",
-                "eors r11, r11, r2",
-                "bics r2, r1, r0",
-                "eors r5, r5, r2",
-                // Col 2
-                "mov  r0, r9",
-                "mov  r1, r12",
-                "bics r2, r6, r1",
-                "eors r9, r9, r2",
-                "bics r2, r0, r6",
-                "eors r12, r12, r2",
-                "bics r2, r1, r0",
-                "eors r6, r6, r2",
-                // Col 3
-                "ldr  r0, [sp, #0]",
-                "mov  r1, lr",
-                "bics r2, r7, r1",
-                "eors r0, r0, r2",
-                "str  r0, [sp, #0]",
-                "bics r2, r0, r7",
-                "eors lr, lr, r2",
-                "bics r2, r1, r0",
-                "eors r7, r7, r2",
+                // x=3 (Col 3)
+                "ldr     r0, [sp, #0]",
+                "mov     r1, lr",
+                "bics    r2, r7, r1",   "eors r0, r0, r2",
+                "str     r0, [sp, #0]",
+                "bics    r2, r0, r7",   "eors lr, lr, r2",
+                "bics    r2, r1, r0",   "eors r7, r7, r2",
 
-                // === ρ East step ===
+                // === ρ (Rho) East step ===
                 // A[x,1] = rot(A[x,1], 1)
+                "movs    r0, #31",                  // rot 1
+                "mov     r1, r10",  "rors r1, r1, r0",  "mov r10, r1",
+                "mov     r1, r11",  "rors r1, r1, r0",  "mov r11, r1",
+                "mov     r1, r12",  "rors r1, r1, r0",  "mov r12, r1",
+                "mov     r1, lr",   "rors r1, r1, r0",  "mov lr, r1",
+
                 // A[x,2] = rot(A[x-2,2], 8)
+                "movs    r0, #24",                  // rot 8
+                "rors    r4, r4, r0",
+                "rors    r5, r5, r0",
+                "rors    r6, r6, r0",
+                "rors    r7, r7, r0",
+                // Cyclic shift Row 2 by 2
+                "mov     r0, r4",   "mov r4, r6",   "mov r6, r0",
+                "mov     r0, r5",   "mov r5, r7",   "mov r7, r0",
 
-                "movs r0, #31",
-                "mov  r1, r10", "rors r1, r1, r0", "mov  r10, r1",
-                "mov  r1, r11", "rors r1, r1, r0", "mov  r11, r1",
-                "mov  r1, r12", "rors r1, r1, r0", "mov  r12, r1",
-                "mov  r1, lr",  "rors r1, r1, r0", "mov  lr, r1",
-
-                "movs r0, #24",
-                "rors r4, r4, r0",
-                "rors r5, r5, r0",
-                "rors r6, r6, r0",
-                "rors r7, r7, r0",
-                "mov  r0, r4",
-                "mov  r4, r6",
-                "mov  r6, r0",
-                "mov  r0, r5",
-                "mov  r5, r7",
-                "mov  r7, r0",
-
-                "ldr  r0, [sp, #8]",
-                "subs r0, r0, #1",
-                "str  r0, [sp, #8]",
-                "beq  1f",
-                "b    0b",
-                "1:",
+                // Loop control
+                "ldr     r0, [sp, #8]",
+                "subs    r0, r0, #1",
+                "str     r0, [sp, #8]",
+                "bne     0b",
 
                 // Save back state
-                "ldr  r0, [sp, #12]",
-                "stm  r0!, {{r3}}",
-                "mov  r1, r8",
-                "mov  r2, r9",
-                "ldr  r3, [sp, #0]",
-                "stm  r0!, {{r1-r3}}",
-                "mov  r1, r10",
-                "mov  r2, r11",
-                "mov  r3, r12",
-                "stm  r0!, {{r1-r3}}",
-                "mov  r1, lr",
-                "stm  r0!, {{r1, r4-r7}}",
+                "ldr     r0, [sp, #12]",
+                "stm     r0!, {{r3}}",
+                "mov     r1, r8",
+                "mov     r2, r9",
+                "ldr     r3, [sp, #0]",
+                "stm     r0!, {{r1-r3}}",
+                "mov     r1, r10",
+                "mov     r2, r11",
+                "mov     r3, r12",
+                "stm     r0!, {{r1-r3}}",
+                "mov     r1, lr",
+                "stm     r0!, {{r1, r4-r7}}",
 
                 // Restore registers
-                "add  sp, sp, #16",
-                "pop  {{r0}}",
-                "mov  r12, r0",
-                "pop  {{r0-r3}}",
-                "mov  r8, r0",
-                "mov  r9, r1",
-                "mov  r10, r2",
-                "mov  r11, r3",
-                "pop  {{r4-r7}}",
-                "pop  {{r0}}",
-                "mov  lr, r0",
+                "add     sp, sp, #16",
+                "pop     {{r0}}",
+                "mov     r12, r0",
+                "pop     {{r0-r3}}",
+                "mov     r8, r0",
+                "mov     r9, r1",
+                "mov     r10, r2",
+                "mov     r11, r3",
+                "pop     {{r4-r7}}",
+                "pop     {{r0}}",
+                "mov     lr, r0",
 
                 rk = in(reg) rkeys,
                 st = in(reg) st_ptr,

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -177,24 +177,28 @@ impl Xoodoo {
                 "mov     r1, r11",
                 "mov     r2, r5",
                 "bics    r2, r1",
-                "eors    r2, r8",
+                "mov     r0, r8",
+                "eors    r2, r0",
                 "mov     r8, r2",                   // a0 = a0_new
                 "bics    r2, r5",
                 "eors    r2, r1",
                 "mov     r11, r2",                  // a1 = a1_new
-                "bics    r2, r8",
+                "mov     r0, r8",
+                "bics    r2, r0",
                 "eors    r5, r2",                   // a2 = a2_new
 
                 // x=2 (Col 2)
                 "mov     r1, r12",
                 "mov     r2, r6",
                 "bics    r2, r1",
-                "eors    r2, r9",
+                "mov     r0, r9",
+                "eors    r2, r0",
                 "mov     r9, r2",                   // a0 = a0_new
                 "bics    r2, r6",
                 "eors    r2, r1",
                 "mov     r12, r2",                  // a1 = a1_new
-                "bics    r2, r9",
+                "mov     r0, r9",
+                "bics    r2, r0",
                 "eors    r6, r2",                   // a2 = a2_new
 
                 // x=3 (Col 3)

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -14,13 +14,11 @@ impl Xoodoo {
             asm!(
                 // Save callee-saved registers
                 "push    {{r4-r11, lr}}",
-                "sub     sp, sp, #12",              // [sp, #0]:rk, [sp, #4]:count, [sp, #8]:st
-
-                // Store initial pointers and counter
-                "str     {rk}, [sp, #0]",
+                // Stack frame: [0]=rk, [4]=count, [8]=st
+                "push    {{{st}}}",                 // [sp, #8]:st
                 "mov     r0, #12",
-                "str     r0, [sp, #4]",
-                "str     {st}, [sp, #8]",
+                "push    {{r0}}",                    // [sp, #4]:count
+                "push    {{{rk}}}",                  // [sp, #0]:rk
 
                 // Load 12-word state into registers
                 // r2-r5: Row 0 (A[0,0]-A[3,0])
@@ -65,7 +63,7 @@ impl Xoodoo {
                 "ror     r0, r0, #27",
                 "eor     r5, r5, r0",   "eor r9, r9, r0",   "eor lr, lr, r0",
 
-                "add     sp, sp, #8",                       // Discard P0, P1
+                "pop     {{r0, r1}}",                       // Discard P0, P1
 
                 // === ρ (Rho) West step ===
                 // A[x,1] = A[x-1,1] (Cyclic shift Row 1)
@@ -134,7 +132,7 @@ impl Xoodoo {
                 "ldr     r0, [sp, #8]",
                 "stmia   r0, {{r2-r12, lr}}",
 
-                "add     sp, sp, #12",
+                "pop     {{r0, r1, r2}}",                   // Discard rk, count, st
                 "pop     {{r4-r11, lr}}",
 
                 rk = in(reg) rkeys,

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -1,7 +1,6 @@
-#![cfg(all(target_arch = "arm", target_has_atomic = "32"))]
+use core::arch::asm;
 
 use super::{Xoodoo, ROUND_KEYS};
-use core::arch::asm;
 
 impl Xoodoo {
     /// Highly optimized Xoodoo permutation for ARMv7-M (Thumb-2).

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -1,8 +1,8 @@
 use super::{Xoodoo, ROUND_KEYS};
-#[cfg(all(target_arch = "arm", target_feature = "thumb2"))]
+#[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
 use core::arch::asm;
 
-#[cfg(all(target_arch = "arm", target_feature = "thumb2"))]
+#[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
 impl Xoodoo {
     #[allow(clippy::many_single_char_names)]
     pub fn permute(&mut self) {

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -1,0 +1,170 @@
+use super::{Xoodoo, ROUND_KEYS};
+#[cfg(all(target_arch = "arm", target_feature = "thumb2"))]
+use core::arch::asm;
+
+#[cfg(all(target_arch = "arm", target_feature = "thumb2"))]
+impl Xoodoo {
+    #[allow(clippy::many_single_char_names)]
+    pub fn permute(&mut self) {
+        let st_ptr = self.st.as_mut_ptr() as *mut u32;
+        let mut rkeys = ROUND_KEYS.as_ptr();
+        let rkeys_end = unsafe { rkeys.add(12) };
+        let c_ptr = unsafe { st_ptr.add(8) };
+
+        unsafe {
+            let mut a0 = *st_ptr.add(0);
+            let mut a1 = *st_ptr.add(1);
+            let mut a2 = *st_ptr.add(2);
+            let mut a3 = *st_ptr.add(3);
+            let mut b0 = *st_ptr.add(4);
+            let mut b1 = *st_ptr.add(5);
+            let mut b2 = *st_ptr.add(6);
+            let mut b3 = *st_ptr.add(7);
+
+            asm!(
+                ".p2align 2",
+                "2:", // .Lround_loop
+
+                // === THETA ===
+                // P0..3 are computed into the b registers temporarily,
+                // so we must save the real B plane to the stack.
+                // We use generic SUB/STR instead of PUSH {b0..b3} because
+                // rustc register allocation may not map b0..b3 to contiguous ascending registers.
+                "sub sp, sp, #16",
+                "str {b0}, [sp, #0]",
+                "str {b1}, [sp, #4]",
+                "str {b2}, [sp, #8]",
+                "str {b3}, [sp, #12]",
+
+                // Theta: Compute P in b0..b3
+                // P0 = a0 ^ b0 ^ c0
+                "ldr {t1}, [{c_ptr}, #0]",
+                "eor {b0}, {a0}, {b0}", "eor {b0}, {b0}, {t1}",
+                // P1
+                "ldr {t1}, [{c_ptr}, #4]",
+                "eor {b1}, {a1}, {b1}", "eor {b1}, {b1}, {t1}",
+                // P2
+                "ldr {t1}, [{c_ptr}, #8]",
+                "eor {b2}, {a2}, {b2}", "eor {b2}, {b2}, {t1}",
+                // P3
+                "ldr {t1}, [{c_ptr}, #12]",
+                "eor {b3}, {a3}, {b3}", "eor {b3}, {b3}, {t1}",
+
+                // Theta: Compute E. E0 = P3.rotr(27) ^ P3.rotr(18)
+                "ror {t1}, {b2}, #27", "eor {t1}, {t1}, {b2}, ror #18", // t1 = E3
+                "ror {t2}, {b1}, #27", "eor {t2}, {t2}, {b1}, ror #18", // t2 = E2
+                "ror {b1}, {b0}, #27", "eor {b1}, {b1}, {b0}, ror #18", // b1 = E1 (P0 is now consumed)
+                "ror {b2}, {b3}, #27", "eor {b2}, {b2}, {b3}, ror #18", // b2 = E0 (P3 is now consumed)
+
+                // Apply E to A completely in registers
+                "eor {a0}, {a0}, {b2}",
+                "eor {a1}, {a1}, {b1}",
+                "eor {a2}, {a2}, {t2}",
+                "eor {a3}, {a3}, {t1}",
+
+                // Apply E to B (which currently lives on the stack)
+                "ldr {b0}, [sp, #0]", "eor {b0}, {b0}, {b2}", "str {b0}, [sp, #0]",
+                "ldr {b0}, [sp, #4]", "eor {b0}, {b0}, {b1}", "str {b0}, [sp, #4]",
+                "ldr {b0}, [sp, #8]", "eor {b0}, {b0}, {t2}", "str {b0}, [sp, #8]",
+                "ldr {b0}, [sp, #12]","eor {b0}, {b0}, {t1}", "str {b0}, [sp, #12]",
+
+                // Apply E to C (lives in main `st` array)
+                "ldr {b0}, [{c_ptr}, #0]", "eor {b0}, {b0}, {b2}", "str {b0}, [{c_ptr}, #0]",
+                "ldr {b0}, [{c_ptr}, #4]", "eor {b0}, {b0}, {b1}", "str {b0}, [{c_ptr}, #4]",
+                "ldr {b0}, [{c_ptr}, #8]", "eor {b0}, {b0}, {t2}", "str {b0}, [{c_ptr}, #8]",
+                "ldr {b0}, [{c_ptr}, #12]","eor {b0}, {b0}, {t1}", "str {b0}, [{c_ptr}, #12]",
+
+                // === RHO WEST ===
+                // B is shifted Left by 1 = Right by 31.
+                // We load B from stack with the column-shifted registry mapping:
+                // Old B3 goes to New B0, Old B0 to New B1, etc.
+                "ldr {b1}, [sp, #0]", "ror {b1}, {b1}, #31",
+                "ldr {b2}, [sp, #4]", "ror {b2}, {b2}, #31",
+                "ldr {b3}, [sp, #8]", "ror {b3}, {b3}, #31",
+                "ldr {b0}, [sp, #12]","ror {b0}, {b0}, #31",
+                // We purposely DO NOT free the sp stack layer here,
+                // so we can seamlessly reuse it as tmp scratch for Chi!
+
+                // === IOTA ===
+                "ldr {t1}, [{rkeys}], #4", // Load Round key & auto increment
+                "eor {a0}, {a0}, {t1}",
+
+                // === CHI and RHO EAST (combined) ===
+                // To minimize scratch register dependencies securely, we process columns one by one
+                // and use the allocated stack layer to temporarily hold `tmpA` across the calculations.
+
+                // Col 0
+                "ldr {t1}, [{c_ptr}, #0]",
+                "ror {t1}, {t1}, #21", // t1 = C0
+                "bic {t2}, {t1}, {b0}", "eor {t2}, {a0}, {t2}", // t2 = tmpA0
+                "str {t2}, [sp, #0]", // Save tmpA0
+                "bic {t2}, {a0}, {t1}", "eor {t2}, {b0}, {t2}", // t2 = tmpB0
+                "bic {a0}, {b0}, {a0}", "eor {t1}, {t1}, {a0}", // t1 = tmpC0
+                "ror {t2}, {t2}, #31", "mov {b0}, {t2}", // rotB = 1L (31R), save B0
+                "ror {t1}, {t1}, #24", "str {t1}, [{c_ptr}, #8]", // rotC = 8L (24R), save to C2!
+                "ldr {a0}, [sp, #0]", // restore A0
+
+                // Col 1
+                "ldr {t1}, [{c_ptr}, #4]",
+                "ror {t1}, {t1}, #21", // t1 = C1
+                "bic {t2}, {t1}, {b1}", "eor {t2}, {a1}, {t2}", // t2 = tmpA1
+                "str {t2}, [sp, #4]", // Save tmpA1
+                "bic {t2}, {a1}, {t1}", "eor {t2}, {b1}, {t2}", // t2 = tmpB1
+                "bic {a1}, {b1}, {a1}", "eor {t1}, {t1}, {a1}", // t1 = tmpC1
+                "ror {t2}, {t2}, #31", "mov {b1}, {t2}", // rotB, save B1
+                "ror {t1}, {t1}, #24", "str {t1}, [{c_ptr}, #12]", // rotC, save to C3!
+                "ldr {a1}, [sp, #4]", // restore A1
+
+                // Col 2
+                "ldr {t1}, [{c_ptr}, #8]",
+                "ror {t1}, {t1}, #21", // t1 = C2
+                "bic {t2}, {t1}, {b2}", "eor {t2}, {a2}, {t2}", // t2 = tmpA2
+                "str {t2}, [sp, #8]", // Save tmpA2
+                "bic {t2}, {a2}, {t1}", "eor {t2}, {b2}, {t2}", // t2 = tmpB2
+                "bic {a2}, {b2}, {a2}", "eor {t1}, {t1}, {a2}", // t1 = tmpC2
+                "ror {t2}, {t2}, #31", "mov {b2}, {t2}", // rotB, save B2
+                "ror {t1}, {t1}, #24", "str {t1}, [{c_ptr}, #0]", // rotC, save to C0!
+                "ldr {a2}, [sp, #8]", // restore A2
+
+                // Col 3
+                "ldr {t1}, [{c_ptr}, #12]",
+                "ror {t1}, {t1}, #21", // t1 = C3
+                "bic {t2}, {t1}, {b3}", "eor {t2}, {a3}, {t2}", // t2 = tmpA3
+                "str {t2}, [sp, #12]", // Save tmpA3
+                "bic {t2}, {a3}, {t1}", "eor {t2}, {b3}, {t2}", // t2 = tmpB3
+                "bic {a3}, {b3}, {a3}", "eor {t1}, {t1}, {a3}", // t1 = tmpC3
+                "ror {t2}, {t2}, #31", "mov {b3}, {t2}", // rotB, save B3
+                "ror {t1}, {t1}, #24", "str {t1}, [{c_ptr}, #4]", // rotC, save to C1!
+                "ldr {a3}, [sp, #12]", // restore A3
+
+                "add sp, sp, #16", // Now we free the scratch stack correctly
+
+                "cmp {rkeys}, {rkeys_end}",
+                "bne 2b",
+
+                a0 = inout(reg) a0,
+                a1 = inout(reg) a1,
+                a2 = inout(reg) a2,
+                a3 = inout(reg) a3,
+                b0 = inout(reg) b0,
+                b1 = inout(reg) b1,
+                b2 = inout(reg) b2,
+                b3 = inout(reg) b3,
+                rkeys = inout(reg) rkeys,
+                rkeys_end = in(reg) rkeys_end,
+                c_ptr = in(reg) c_ptr,
+                t1 = out(reg) _,
+                t2 = out(reg) _,
+            );
+
+            *st_ptr.add(0) = a0;
+            *st_ptr.add(1) = a1;
+            *st_ptr.add(2) = a2;
+            *st_ptr.add(3) = a3;
+            *st_ptr.add(4) = b0;
+            *st_ptr.add(5) = b1;
+            *st_ptr.add(6) = b2;
+            *st_ptr.add(7) = b3;
+        }
+    }
+}

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -5,9 +5,6 @@ use core::arch::asm;
 #[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
 impl Xoodoo {
     /// Optimized Xoodoo permutation for ARMv7-M (Thumb-2).
-    /// This version keeps Plane A and Plane B in registers (8 total) to maximize speed
-    /// while keeping register pressure low enough for reliable compilation on all
-    /// Thumb-2 targets. Plane C is handled via memory operations to save registers.
     #[allow(clippy::many_single_char_names)]
     pub fn permute(&mut self) {
         let rkeys = ROUND_KEYS.as_ptr();
@@ -24,94 +21,105 @@ impl Xoodoo {
             let mut rk = rkeys;
 
             asm!(
-                "mov r0, #12",           // Round counter
+                "mov  r0, #12",                 // Round counter
                 ".p2align 2",
                 "3:",
-                "push {{r0}}",           // Save counter
+                "push {{r0}}",                   // Save counter
 
-                // === THETA ===
-                // Compute P_i = A_i ^ B_i ^ C_i. Must be done before applying Iota/Mixer.
-                "ldr r0, [{st}, #32]", "eor r0, r0, {a0}", "eor r0, r0, {b0}", "push {{r0}}", // P0 at [sp, #0]
-                "ldr r0, [{st}, #36]", "eor r0, r0, {a1}", "eor r0, r0, {b1}", "push {{r0}}", // P1 at [sp, #0], P0 at [sp, #4]
-                "ldr r0, [{st}, #40]", "eor r0, r0, {a2}", "eor r0, r0, {b2}", "push {{r0}}", // P2 at [sp, #0], P1 at [sp, #4], P0 at [sp, #8]
-                "ldr r0, [{st}, #44]", "eor r0, r0, {a3}", "eor r0, r0, {b3}",                 // r0 = P3
+                // === θ step ===
+                // P[x] = A[x,0] ^ A[x,1] ^ A[x,2]
+                // E[x] = rot(P[x-1], 5) ^ rot(P[x-1], 14)
+                // A[x,y] = A[x,y] ^ E[x]
 
-                // --- IOTA ---
-                // Load Round Constant and apply to a0.
-                "ldr r1, [{rk}], #4",
-                "eor {a0}, {a0}, r1",
+                "ldr  r0, [{st}, #32]", "eor  r0, r0, {a0}", "eor  r0, r0, {b0}", "push {{r0}}", // P0 at [sp, #0]
+                "ldr  r0, [{st}, #36]", "eor  r0, r0, {a1}", "eor  r0, r0, {b1}", "push {{r0}}", // P1 at [sp, #0], P0 at [sp, #4]
+                "ldr  r0, [{st}, #40]", "eor  r0, r0, {a2}", "eor  r0, r0, {b2}", "push {{r0}}", // P2 at [sp, #0], P1 at [sp, #4], P0 at [sp, #8]
+                "ldr  r0, [{st}, #44]", "eor  r0, r0, {a3}", "eor  r0, r0, {b3}",                 // r0 = P3
 
-                // Apply Mixer: E_i = P_{i-1}.rot(5) ^ P_{i-1}.rot(14)
-                // rot(5) = ROR 27, rot(14) = ROR 18
-                "ror r1, r0, #27", "eor r1, r1, r0, ror #18", // r1 = E0 (from P3 in r0)
-                "eor {a0}, {a0}, r1", "eor {b0}, {b0}, r1",
-                "ldr r0, [{st}, #32]", "eor r0, r0, r1", "str r0, [{st}, #32]",
+                // Apply E0..E3
+                "ror  r1, r0, #27", "eor  r1, r1, r0, ror #18", // r1 = E0 (from P3)
+                "eor  {a0}, {a0}, r1", "eor  {b0}, {b0}, r1",
+                "ldr  r0, [{st}, #32]", "eor  r0, r0, r1", "str  r0, [{st}, #32]",
 
-                "ldr r0, [sp, #8]",      // P0
-                "ror r1, r0, #27", "eor r1, r1, r0, ror #18", // r1 = E1
-                "eor {a1}, {a1}, r1", "eor {b1}, {b1}, r1",
-                "ldr r0, [{st}, #36]", "eor r0, r0, r1", "str r0, [{st}, #36]",
+                "ldr  r0, [sp, #8]",             // P0
+                "ror  r1, r0, #27", "eor  r1, r1, r0, ror #18", // r1 = E1
+                "eor  {a1}, {a1}, r1", "eor  {b1}, {b1}, r1",
+                "ldr  r0, [{st}, #36]", "eor  r0, r0, r1", "str  r0, [{st}, #36]",
 
-                "ldr r0, [sp, #4]",      // P1
-                "ror r1, r0, #27", "eor r1, r1, r0, ror #18", // r1 = E2
-                "eor {a2}, {a2}, r1", "eor {b2}, {b2}, r1",
-                "ldr r0, [{st}, #40]", "eor r0, r0, r1", "str r0, [{st}, #40]",
+                "ldr  r0, [sp, #4]",             // P1
+                "ror  r1, r0, #27", "eor  r1, r1, r0, ror #18", // r1 = E2
+                "eor  {a2}, {a2}, r1", "eor  {b2}, {b2}, r1",
+                "ldr  r0, [{st}, #40]", "eor  r0, r0, r1", "str  r0, [{st}, #40]",
 
-                "ldr r0, [sp, #0]",      // P2
-                "ror r1, r0, #27", "eor r1, r1, r0, ror #18", // r1 = E3
-                "eor {a3}, {a3}, r1", "eor {b3}, {b3}, r1",
-                "ldr r0, [{st}, #44]", "eor r0, r0, r1", "str r0, [{st}, #44]",
+                "ldr  r0, [sp, #0]",             // P2
+                "ror  r1, r0, #27", "eor  r1, r1, r0, ror #18", // r1 = E3
+                "eor  {a3}, {a3}, r1", "eor  {b3}, {b3}, r1",
+                "ldr  r0, [{st}, #44]", "eor  r0, r0, r1", "str  r0, [{st}, #44]",
 
-                "add sp, sp, #12",       // Clean P results
+                "add  sp, sp, #12",              // Clean P results
 
-                // === RHO WEST ===
-                "mov r0, {b3}", "mov {b3}, {b2}", "mov {b2}, {b1}", "mov {b1}, {b0}", "mov {b0}, r0",
-                "ldr r0, [{st}, #32]", "ror r0, r0, #21", "str r0, [{st}, #32]",
-                "ldr r0, [{st}, #36]", "ror r0, r0, #21", "str r0, [{st}, #36]",
-                "ldr r0, [{st}, #40]", "ror r0, r0, #21", "str r0, [{st}, #40]",
-                "ldr r0, [{st}, #44]", "ror r0, r0, #21", "str r0, [{st}, #44]",
+                // === ρ West step ===
+                // A[x,1] = A[x-1,1]
+                // A[x,2] = rot(A[x,2], 11)
 
-                // === CHI ===
-                // Column 0
-                "mov r1, {a0}", "push {{{b0}}}",
-                "ldr r0, [{st}, #32]", "bic r0, r0, {b0}", "eor {a0}, {a0}, r0",
-                "ldr r0, [{st}, #32]", "bic r0, r1, r0", "eor {b0}, {b0}, r0",
-                "pop {{r0}}", "bic r0, r0, r1",
-                "ldr r1, [{st}, #32]", "eor r0, r0, r1", "str r0, [{st}, #32]",
+                "mov  r0, {b3}", "mov  {b3}, {b2}", "mov  {b2}, {b1}", "mov  {b1}, {b0}", "mov  {b0}, r0",
+                "ldr  r0, [{st}, #32]", "ror  r0, r0, #21", "str  r0, [{st}, #32]",
+                "ldr  r0, [{st}, #36]", "ror  r0, r0, #21", "str  r0, [{st}, #36]",
+                "ldr  r0, [{st}, #40]", "ror  r0, r0, #21", "str  r0, [{st}, #40]",
+                "ldr  r0, [{st}, #44]", "ror  r0, r0, #21", "str  r0, [{st}, #44]",
 
-                // Column 1
-                "mov r1, {a1}", "push {{{b1}}}",
-                "ldr r0, [{st}, #36]", "bic r0, r0, {b1}", "eor {a1}, {a1}, r0",
-                "ldr r0, [{st}, #36]", "bic r0, r1, r0", "eor {b1}, {b1}, r0",
-                "pop {{r0}}", "bic r0, r0, r1",
-                "ldr r1, [{st}, #36]", "eor r0, r0, r1", "str r0, [{st}, #36]",
+                // === ι step ===
+                // A[0,0] = A[0,0] ^ RC
 
-                // Column 2
-                "mov r1, {a2}", "push {{{b2}}}",
-                "ldr r0, [{st}, #40]", "bic r0, r0, {b2}", "eor {a2}, {a2}, r0",
-                "ldr r0, [{st}, #40]", "bic r0, r1, r0", "eor {b2}, {b2}, r0",
-                "pop {{r0}}", "bic r0, r0, r1",
-                "ldr r1, [{st}, #40]", "eor r0, r0, r1", "str r0, [{st}, #40]",
+                "ldr  r1, [{rk}], #4",
+                "eor  {a0}, {a0}, r1",
 
-                // Column 3
-                "mov r1, {a3}", "push {{{b3}}}",
-                "ldr r0, [{st}, #44]", "bic r0, r0, {b3}", "eor {a3}, {a3}, r0",
-                "ldr r0, [{st}, #44]", "bic r0, r1, r0", "eor {b3}, {b3}, r0",
-                "pop {{r0}}", "bic r0, r0, r1",
-                "ldr r1, [{st}, #44]", "eor r0, r0, r1", "str r0, [{st}, #44]",
+                // === χ step ===
+                // A[x,y] = A[x,y] ^ ((not A[x,y+1]) and A[x,y+2])
 
-                // === RHO EAST ===
-                "ror {b0}, {b0}, #31", "ror {b1}, {b1}, #31", "ror {b2}, {b2}, #31", "ror {b3}, {b3}, #31",
-                "ldr r0, [{st}, #32]", "ldr r1, [{st}, #40]", "str r0, [{st}, #40]", "str r1, [{st}, #32]",
-                "ldr r0, [{st}, #36]", "ldr r1, [{st}, #44]", "str r0, [{st}, #44]", "str r1, [{st}, #36]",
-                "ldr r0, [{st}, #32]", "ror r0, r0, #24", "str r0, [{st}, #32]",
-                "ldr r0, [{st}, #36]", "ror r0, r0, #24", "str r0, [{st}, #36]",
-                "ldr r0, [{st}, #40]", "ror r0, r0, #24", "str r0, [{st}, #40]",
-                "ldr r0, [{st}, #44]", "ror r0, r0, #24", "str r0, [{st}, #44]",
+                // Col 0
+                "mov  r1, {a0}", "push {{{b0}}}",
+                "ldr  r0, [{st}, #32]", "bic  r0, r0, {b0}", "eor  {a0}, {a0}, r0",
+                "ldr  r0, [{st}, #32]", "bic  r0, r1, r0", "eor  {b0}, {b0}, r0",
+                "pop  {{r0}}", "bic  r0, r0, r1",
+                "ldr  r1, [{st}, #32]", "eor  r0, r0, r1", "str  r0, [{st}, #32]",
 
-                "pop {{r0}}",            // Restore loop counter
+                // Col 1
+                "mov  r1, {a1}", "push {{{b1}}}",
+                "ldr  r0, [{st}, #36]", "bic  r0, r0, {b1}", "eor  {a1}, {a1}, r0",
+                "ldr  r0, [{st}, #36]", "bic  r0, r1, r0", "eor  {b1}, {b1}, r0",
+                "pop  {{r0}}", "bic  r0, r0, r1",
+                "ldr  r1, [{st}, #36]", "eor  r0, r0, r1", "str  r0, [{st}, #36]",
+
+                // Col 2
+                "mov  r1, {a2}", "push {{{b2}}}",
+                "ldr  r0, [{st}, #40]", "bic  r0, r0, {b2}", "eor  {a2}, {a2}, r0",
+                "ldr  r0, [{st}, #40]", "bic  r0, r1, r0", "eor  {b2}, {b2}, r0",
+                "pop  {{r0}}", "bic  r0, r0, r1",
+                "ldr  r1, [{st}, #40]", "eor  r0, r0, r1", "str  r0, [{st}, #40]",
+
+                // Col 3
+                "mov  r1, {a3}", "push {{{b3}}}",
+                "ldr  r0, [{st}, #44]", "bic  r0, r0, {b3}", "eor  {a3}, {a3}, r0",
+                "ldr  r0, [{st}, #44]", "bic  r0, r1, r0", "eor  {b3}, {b3}, r0",
+                "pop  {{r0}}", "bic  r0, r0, r1",
+                "ldr  r1, [{st}, #44]", "eor  r0, r0, r1", "str  r0, [{st}, #44]",
+
+                // === ρ East step ===
+                // A[x,1] = rot(A[x,1], 1)
+                // A[x,2] = rot(A[x-2,2], 8)
+
+                "ror  {b0}, {b0}, #31", "ror  {b1}, {b1}, #31", "ror  {b2}, {b2}, #31", "ror  {b3}, {b3}, #31",
+                "ldr  r0, [{st}, #32]", "ldr  r1, [{st}, #40]", "str  r0, [{st}, #40]", "str  r1, [{st}, #32]",
+                "ldr  r0, [{st}, #36]", "ldr  r1, [{st}, #44]", "str  r0, [{st}, #44]", "str  r1, [{st}, #36]",
+                "ldr  r0, [{st}, #32]", "ror  r0, r0, #24", "str  r0, [{st}, #32]",
+                "ldr  r0, [{st}, #36]", "ror  r0, r0, #24", "str  r0, [{st}, #36]",
+                "ldr  r0, [{st}, #40]", "ror  r0, r0, #24", "str  r0, [{st}, #40]",
+                "ldr  r0, [{st}, #44]", "ror  r0, r0, #24", "str  r0, [{st}, #44]",
+
+                "pop  {{r0}}",                   // Restore loop counter
                 "subs r0, #1",
-                "bne 3b",
+                "bne  3b",
 
                 st = in(reg) st_ptr,
                 rk = inout(reg) rk,

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -14,17 +14,16 @@ impl Xoodoo {
             asm!(
                 // Save callee-saved registers
                 "push    {{r4-r11, lr}}",
-                // Stack frame: [0]=rk, [4]=count, [8]=st
-                "push    {{{st}}}",                 // [sp, #8]:st
-                "mov     r0, #12",
-                "push    {{r0}}",                    // [sp, #4]:count
-                "push    {{{rk}}}",                  // [sp, #0]:rk
+                // Stack frame: [sp, #4]=st, [sp, #0]=rk
+                "push    {{{st}}}",
+                "push    {{{rk}}}",
+                "mov     r1, #12",                // r1 = round counter
 
                 // Load 12-word state into registers
                 // r2-r5: Row 0 (A[0,0]-A[3,0])
                 // r6-r9: Row 1 (A[0,1]-A[3,1])
                 // r10-r12, lr: Row 2 (A[0,2]-A[3,2])
-                "ldr     r0, [sp, #8]",
+                "ldr     r0, [sp, #4]",
                 "ldmia   r0, {{r2-r12, lr}}",
 
                 ".p2align 2",
@@ -32,38 +31,25 @@ impl Xoodoo {
 
                 // === θ (Theta) step ===
                 // P[x] = A[x,0] ^ A[x,1] ^ A[x,2]
+                // OPTIMIZATION: "Parity Correction". Instead of storing P[x] on stack,
+                // we update columns sequentially. Original parity of a modified column
+                // is recovered by P_orig = P_updated ^ E_applied.
+
                 "eor     r0, r2, r6",   "eor r0, r0, r10",  // r0 = P0
-                "eor     r1, r3, r7",   "eor r1, r1, r11",  // r1 = P1
-                "push    {{r0, r1}}",                       // Save P0, P1
-                "eor     r0, r4, r8",   "eor r0, r0, r12",  // r0 = P2
-                "eor     r1, r5, r9",   "eor r1, r1, lr",   // r1 = P3
+                "eor     r0, r0, r0, ror #23", "ror r0, r0, #27", // r0 = E1
+                "eor     r3, r3, r0",   "eor r7, r7, r0",   "eor r11, r11, r0", // Update Col 1
 
-                // E[x] = rot(P[x-1], 5) ^ rot(P[x-1], 14)
-                // Note: (P ^ rot(P, 9)).rot(5) == rot(P, 5) ^ rot(P, 14)
+                "eor     r0, r0, r3",   "eor r0, r0, r7",   "eor r0, r0, r11",  // r0 = P1
+                "eor     r0, r0, r0, ror #23", "ror r0, r0, #27", // r0 = E2
+                "eor     r4, r4, r0",   "eor r8, r8, r0",   "eor r12, r12, r0", // Update Col 2
 
-                // E0: depends on P3 (r1)
-                "eor     r1, r1, r1, ror #23",
-                "ror     r1, r1, #27",
-                "eor     r2, r2, r1",   "eor r6, r6, r1",   "eor r10, r10, r1",
+                "eor     r0, r0, r4",   "eor r0, r0, r8",   "eor r0, r0, r12",  // r0 = P2
+                "eor     r0, r0, r0, ror #23", "ror r0, r0, #27", // r0 = E3
+                "eor     r5, r5, r0",   "eor r9, r9, r0",   "eor lr, lr, r0",   // Update Col 3
 
-                // E1: depends on P0 (stack offset 0)
-                "ldr     r1, [sp, #0]",
-                "eor     r1, r1, r1, ror #23",
-                "ror     r1, r1, #27",
-                "eor     r3, r3, r1",   "eor r7, r7, r1",   "eor r11, r11, r1",
-
-                // E2: depends on P1 (stack offset 4)
-                "ldr     r1, [sp, #4]",
-                "eor     r1, r1, r1, ror #23",
-                "ror     r1, r1, #27",
-                "eor     r4, r4, r1",   "eor r8, r8, r1",   "eor r12, r12, r1",
-
-                // E3: depends on P2 (r0)
-                "eor     r0, r0, r0, ror #23",
-                "ror     r0, r0, #27",
-                "eor     r5, r5, r0",   "eor r9, r9, r0",   "eor lr, lr, r0",
-
-                "pop     {{r0, r1}}",                       // Discard P0, P1
+                "eor     r0, r0, r5",   "eor r0, r0, r9",   "eor r0, r0, lr",   // r0 = P3
+                "eor     r0, r0, r0, ror #23", "ror r0, r0, #27", // r0 = E0
+                "eor     r2, r2, r0",   "eor r6, r6, r0",   "eor r10, r10, r0", // Update Col 0
 
                 // === ρ (Rho) West step ===
                 // A[x,1] = A[x-1,1] (Cyclic shift Row 1)
@@ -80,25 +66,24 @@ impl Xoodoo {
                 "ror     lr, lr, #21",
 
                 // === ι (Iota) step ===
-                "ldr     r0, [sp, #0]",                    // Load rk pointer
-                "ldr     r1, [r0], #4",                    // Load RC and increment
-                "str     r0, [sp, #0]",                    // Save rk pointer
-                "eor     r2, r2, r1",                      // A[0,0] ^= RC
+                // A[0,0] = A[0,0] ^ RC
+                "ldr     r0, [sp, #0]",                    // Get rk_ptr
+                "add     r0, r0, #4",                      // Increment
+                "str     r0, [sp, #0]",                    // Save incremented pointer back
+                "ldr     r0, [r0, #-4]",                   // Load RC (post-incremented access)
+                "eor     r2, r2, r0",                      // A[0,0] ^= RC
 
                 // === χ (Chi) step ===
                 // A[x,y] ^= (~A[x,y+1]) & A[x,y+2]
                 "bic     r0, r10, r6",  "eor r2, r2, r0",
                 "bic     r0, r2, r10",  "eor r6, r6, r0",
                 "bic     r0, r6, r2",   "eor r10, r10, r0",
-
                 "bic     r0, r11, r7",  "eor r3, r3, r0",
                 "bic     r0, r3, r11",  "eor r7, r7, r0",
                 "bic     r0, r7, r3",   "eor r11, r11, r0",
-
                 "bic     r0, r12, r8",  "eor r4, r4, r0",
                 "bic     r0, r4, r12",  "eor r8, r8, r0",
                 "bic     r0, r8, r4",   "eor r12, r12, r0",
-
                 "bic     r0, lr, r9",   "eor r5, r5, r0",
                 "bic     r0, r5, lr",   "eor r9, r9, r0",
                 "bic     r0, r9, r5",   "eor lr, lr, r0",
@@ -111,28 +96,23 @@ impl Xoodoo {
                 "ror     r9, r9, #31",
 
                 // A[x,2] = rot(A[x-2,2], 8)
+                // OPTIMIZATION: Folded rotation into register move using barrel shifter.
                 "mov     r0, r10",
-                "mov     r1, r11",
-                "mov     r10, r12",
-                "mov     r11, lr",
-                "mov     r12, r0",
-                "mov     lr, r1",
-                "ror     r10, r10, #24",
-                "ror     r11, r11, #24",
-                "ror     r12, r12, #24",
-                "ror     lr, lr, #24",
+                "mov     r10, r12, ror #24",
+                "mov     r12, r0,  ror #24",
+                "mov     r0, r11",
+                "mov     r11, lr,  ror #24",
+                "mov     lr,  r0,  ror #24",
 
                 // Loop control
-                "ldr     r0, [sp, #4]",
-                "subs    r0, r0, #1",
-                "str     r0, [sp, #4]",
+                "subs    r1, r1, #1",
                 "bne     0b",
 
                 // Store state back
-                "ldr     r0, [sp, #8]",
+                "ldr     r0, [sp, #4]",
                 "stmia   r0, {{r2-r12, lr}}",
 
-                "pop     {{r0, r1, r2}}",                   // Discard rk, count, st
+                "pop     {{r0, r1}}",                       // Discard rk, st
                 "pop     {{r4-r11, lr}}",
 
                 rk = in(reg) rkeys,

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -4,140 +4,102 @@ use super::{Xoodoo, ROUND_KEYS};
 use core::arch::asm;
 
 impl Xoodoo {
-    /// Optimized Xoodoo permutation for ARMv7-M (Thumb-2).
+    /// Highly optimized Xoodoo permutation for ARMv7-M (Thumb-2).
+    /// Uses all available registers to eliminate memory spills.
     #[allow(clippy::many_single_char_names)]
     pub fn permute(&mut self) {
         let rkeys = ROUND_KEYS.as_ptr();
         unsafe {
             let st_ptr = self.st.as_mut_ptr() as *mut u32;
-            let mut a0 = *st_ptr.add(0);
-            let mut a1 = *st_ptr.add(1);
-            let mut a2 = *st_ptr.add(2);
-            let mut a3 = *st_ptr.add(3);
-            let mut b0 = *st_ptr.add(4);
-            let mut b1 = *st_ptr.add(5);
-            let mut b2 = *st_ptr.add(6);
-            let mut b3 = *st_ptr.add(7);
-            let mut rk = rkeys;
 
             asm!(
-                "mov  r0, #12",                 // Round counter
-                ".p2align 2",
-                "3:",
-                "push {{r0}}",                   // Save counter
+                "push {{r4-r11, lr}}",
+                "sub  sp, sp, #12",              // [sp, #0]:rk, [sp, #4]:count, [sp, #8]:st
+                "str  {rk}, [sp, #0]",
+                "mov  r0, #12",
+                "str  r0, [sp, #4]",
+                "str  {st}, [sp, #8]",
 
+                // Load entire 12-word state into registers
+                // r2-r5: Row 0
+                // r6-r9: Row 1
+                // r10-r12, lr: Row 2
+                "ldr  r0, [sp, #8]",
+                "ldmia r0, {{r2-r12, lr}}",
+
+                ".p2align 2",
+                "0:",
                 // === θ step ===
                 // P[x] = A[x,0] ^ A[x,1] ^ A[x,2]
-                // E[x] = rot(P[x-1], 5) ^ rot(P[x-1], 14)
-                // A[x,y] = A[x,y] ^ E[x]
+                "eor  r0, r2, r6",  "eor  r0, r0, r10", // r0 = P0
+                "eor  r1, r3, r7",  "eor  r1, r1, r11", // r1 = P1
+                "push {{r0, r1}}",                      // Save P0, P1 to stack
+                "eor  r0, r4, r8",  "eor  r0, r0, r12", // r0 = P2
+                "eor  r1, r5, r9",  "eor  r1, r1, lr",  // r1 = P3
 
-                "ldr  r0, [{st}, #32]", "eor  r0, r0, {a0}", "eor  r0, r0, {b0}", "push {{r0}}", // P0 at [sp, #0]
-                "ldr  r0, [{st}, #36]", "eor  r0, r0, {a1}", "eor  r0, r0, {b1}", "push {{r0}}", // P1 at [sp, #0], P0 at [sp, #4]
-                "ldr  r0, [{st}, #40]", "eor  r0, r0, {a2}", "eor  r0, r0, {b2}", "push {{r0}}", // P2 at [sp, #0], P1 at [sp, #4], P0 at [sp, #8]
-                "ldr  r0, [{st}, #44]", "eor  r0, r0, {a3}", "eor  r0, r0, {b3}",                 // r0 = P3
+                // E[x] = (P[x-1] ^ rot(P[x-1], 9)).rot(5)
 
-                // Apply E0..E3
-                "ror  r1, r0, #27", "eor  r1, r1, r0, ror #18", // r1 = E0 (from P3)
-                "eor  {a0}, {a0}, r1", "eor  {b0}, {b0}, r1",
-                "ldr  r0, [{st}, #32]", "eor  r0, r0, r1", "str  r0, [{st}, #32]",
+                // E0 depends on P3 (r1)
+                "eor  r1, r1, r1, ror #23", "ror r1, r1, #27",
+                "eor  r2, r2, r1", "eor  r6, r6, r1", "eor  r10, r10, r1",
 
-                "ldr  r0, [sp, #8]",             // P0
-                "ror  r1, r0, #27", "eor  r1, r1, r0, ror #18", // r1 = E1
-                "eor  {a1}, {a1}, r1", "eor  {b1}, {b1}, r1",
-                "ldr  r0, [{st}, #36]", "eor  r0, r0, r1", "str  r0, [{st}, #36]",
+                // E1 depends on P0 (stack offset 0)
+                "ldr  r1, [sp, #0]",
+                "eor  r1, r1, r1, ror #23", "ror r1, r1, #27",
+                "eor  r3, r3, r1",  "eor  r7, r7, r1",  "eor  r11, r11, r1",
 
-                "ldr  r0, [sp, #4]",             // P1
-                "ror  r1, r0, #27", "eor  r1, r1, r0, ror #18", // r1 = E2
-                "eor  {a2}, {a2}, r1", "eor  {b2}, {b2}, r1",
-                "ldr  r0, [{st}, #40]", "eor  r0, r0, r1", "str  r0, [{st}, #40]",
+                // E2 depends on P1 (stack offset 4)
+                "ldr  r1, [sp, #4]",
+                "eor  r1, r1, r1, ror #23", "ror r1, r1, #27",
+                "eor  r4, r4, r1",  "eor  r8, r8, r1",  "eor  r12, r12, r1",
 
-                "ldr  r0, [sp, #0]",             // P2
-                "ror  r1, r0, #27", "eor  r1, r1, r0, ror #18", // r1 = E3
-                "eor  {a3}, {a3}, r1", "eor  {b3}, {b3}, r1",
-                "ldr  r0, [{st}, #44]", "eor  r0, r0, r1", "str  r0, [{st}, #44]",
+                // E3 depends on P2 (r0)
+                "eor  r0, r0, r0, ror #23",  "ror r0, r0, #27",
+                "eor  r5, r5, r0",  "eor  r9, r9, r0",  "eor  lr, lr, r0",
 
-                "add  sp, sp, #12",              // Clean P results
+                "add  sp, sp, #8",                      // Clean P0, P1 from stack
 
                 // === ρ West step ===
-                // A[x,1] = A[x-1,1]
-                // A[x,2] = rot(A[x,2], 11)
-
-                "mov  r0, {b3}", "mov  {b3}, {b2}", "mov  {b2}, {b1}", "mov  {b1}, {b0}", "mov  {b0}, r0",
-                "ldr  r0, [{st}, #32]", "ror  r0, r0, #21", "str  r0, [{st}, #32]",
-                "ldr  r0, [{st}, #36]", "ror  r0, r0, #21", "str  r0, [{st}, #36]",
-                "ldr  r0, [{st}, #40]", "ror  r0, r0, #21", "str  r0, [{st}, #40]",
-                "ldr  r0, [{st}, #44]", "ror  r0, r0, #21", "str  r0, [{st}, #44]",
+                // Row 1: cyclic shift right 1
+                "mov  r0, r9", "mov  r9, r8", "mov  r8, r7", "mov  r7, r6", "mov  r6, r0",
+                // Row 2: bit rotation 11
+                "ror  r10, r10, #21", "ror  r11, r11, #21", "ror  r12, r12, #21", "ror  lr, lr, #21",
 
                 // === ι step ===
-                // A[0,0] = A[0,0] ^ RC
-
-                "ldr  r1, [{rk}], #4",
-                "eor  {a0}, {a0}, r1",
+                "ldr  r0, [sp, #0]",                    // load rk pointer
+                "ldr  r1, [r0], #4",                    // load rc and increment rk
+                "str  r0, [sp, #0]",                    // save rk pointer
+                "eor  r2, r2, r1",
 
                 // === χ step ===
-                // A[x,y] = A[x,y] ^ ((not A[x,y+1]) and A[x,y+2])
-
-                // Col 0
-                "mov  r1, {a0}", "push {{{b0}}}",
-                "ldr  r0, [{st}, #32]", "bic  r0, r0, {b0}", "eor  {a0}, {a0}, r0",
-                "ldr  r0, [{st}, #32]", "bic  r0, r1, r0", "eor  {b0}, {b0}, r0",
-                "pop  {{r0}}", "bic  r0, r0, r1",
-                "ldr  r1, [{st}, #32]", "eor  r0, r0, r1", "str  r0, [{st}, #32]",
-
-                // Col 1
-                "mov  r1, {a1}", "push {{{b1}}}",
-                "ldr  r0, [{st}, #36]", "bic  r0, r0, {b1}", "eor  {a1}, {a1}, r0",
-                "ldr  r0, [{st}, #36]", "bic  r0, r1, r0", "eor  {b1}, {b1}, r0",
-                "pop  {{r0}}", "bic  r0, r0, r1",
-                "ldr  r1, [{st}, #36]", "eor  r0, r0, r1", "str  r0, [{st}, #36]",
-
-                // Col 2
-                "mov  r1, {a2}", "push {{{b2}}}",
-                "ldr  r0, [{st}, #40]", "bic  r0, r0, {b2}", "eor  {a2}, {a2}, r0",
-                "ldr  r0, [{st}, #40]", "bic  r0, r1, r0", "eor  {b2}, {b2}, r0",
-                "pop  {{r0}}", "bic  r0, r0, r1",
-                "ldr  r1, [{st}, #40]", "eor  r0, r0, r1", "str  r0, [{st}, #40]",
-
-                // Col 3
-                "mov  r1, {a3}", "push {{{b3}}}",
-                "ldr  r0, [{st}, #44]", "bic  r0, r0, {b3}", "eor  {a3}, {a3}, r0",
-                "ldr  r0, [{st}, #44]", "bic  r0, r1, r0", "eor  {b3}, {b3}, r0",
-                "pop  {{r0}}", "bic  r0, r0, r1",
-                "ldr  r1, [{st}, #44]", "eor  r0, r0, r1", "str  r0, [{st}, #44]",
+                "bic  r0, r10, r6",  "eor  r2, r2, r0",  "bic  r0, r2, r10",  "eor  r6, r6, r0",  "bic  r0, r6, r2",   "eor  r10, r10, r0",
+                "bic  r0, r11, r7",  "eor  r3, r3, r0",  "bic  r0, r3, r11",  "eor  r7, r7, r0",  "bic  r0, r7, r3",   "eor  r11, r11, r0",
+                "bic  r0, r12, r8",  "eor  r4, r4, r0",  "bic  r0, r4, r12",  "eor  r8, r8, r0",  "bic  r0, r8, r4",   "eor  r12, r12, r0",
+                "bic  r0, lr, r9",   "eor  r5, r5, r0",  "bic  r0, r5, lr",   "eor  r9, r9, r0",  "bic  r0, r9, r5",   "eor  lr, lr, r0",
 
                 // === ρ East step ===
-                // A[x,1] = rot(A[x,1], 1)
-                // A[x,2] = rot(A[x-2,2], 8)
+                // Row 1: bit rotation 1
+                "ror  r6, r6, #31", "ror  r7, r7, #31", "ror  r8, r8, #31", "ror  r9, r9, #31",
+                // Row 2: cyclic shift right 2 + bit rotation 8
+                "mov  r0, r10", "mov  r1, r11", "mov  r10, r12", "mov  r11, lr", "mov  r12, r0", "mov  lr, r1",
+                "ror  r10, r10, #24", "ror  r11, r11, #24", "ror  r12, r12, #24", "ror  lr, lr, #24",
 
-                "ror  {b0}, {b0}, #31", "ror  {b1}, {b1}, #31", "ror  {b2}, {b2}, #31", "ror  {b3}, {b3}, #31",
-                "ldr  r0, [{st}, #32]", "ldr  r1, [{st}, #40]", "str  r0, [{st}, #40]", "str  r1, [{st}, #32]",
-                "ldr  r0, [{st}, #36]", "ldr  r1, [{st}, #44]", "str  r0, [{st}, #44]", "str  r1, [{st}, #36]",
-                "ldr  r0, [{st}, #32]", "ror  r0, r0, #24", "str  r0, [{st}, #32]",
-                "ldr  r0, [{st}, #36]", "ror  r0, r0, #24", "str  r0, [{st}, #36]",
-                "ldr  r0, [{st}, #40]", "ror  r0, r0, #24", "str  r0, [{st}, #40]",
-                "ldr  r0, [{st}, #44]", "ror  r0, r0, #24", "str  r0, [{st}, #44]",
+                "ldr  r0, [sp, #4]",                    // load counter
+                "subs r0, r0, #1",
+                "str  r0, [sp, #4]",                    // save counter
+                "bne  0b",
 
-                "pop  {{r0}}",                   // Restore loop counter
-                "subs r0, #1",
-                "bne  3b",
+                "ldr  r0, [sp, #8]",                    // load initial st pointer
+                "stmia r0, {{r2-r12, lr}}",             // Save back state
 
+                "add  sp, sp, #12",
+                "pop  {{r4-r11, lr}}",                  // Restore and return
+
+                rk = in(reg) rkeys,
                 st = in(reg) st_ptr,
-                rk = inout(reg) rk,
-                a0 = inout(reg) a0, a1 = inout(reg) a1, a2 = inout(reg) a2, a3 = inout(reg) a3,
-                b0 = inout(reg) b0, b1 = inout(reg) b1, b2 = inout(reg) b2, b3 = inout(reg) b3,
-                out("r0") _,
-                out("r1") _,
+                out("r0") _, out("r1") _, out("r2") _, out("r3") _,
+                out("r12") _,
             );
-
-            *st_ptr.add(0) = a0;
-            *st_ptr.add(1) = a1;
-            *st_ptr.add(2) = a2;
-            *st_ptr.add(3) = a3;
-            *st_ptr.add(4) = b0;
-            *st_ptr.add(5) = b1;
-            *st_ptr.add(6) = b2;
-            *st_ptr.add(7) = b3;
-            let _ = rk;
         }
     }
 }

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -13,87 +13,130 @@ impl Xoodoo {
             let st_ptr = self.st.as_mut_ptr() as *mut u32;
 
             asm!(
-                "push {{r4-r11, lr}}",
-                "sub  sp, sp, #12",              // [sp, #0]:rk, [sp, #4]:count, [sp, #8]:st
-                "str  {rk}, [sp, #0]",
-                "mov  r0, #12",
-                "str  r0, [sp, #4]",
-                "str  {st}, [sp, #8]",
+                // Save callee-saved registers
+                "push    {{r4-r11, lr}}",
+                "sub     sp, sp, #12",              // [sp, #0]:rk, [sp, #4]:count, [sp, #8]:st
 
-                // Load entire 12-word state into registers
-                // r2-r5: Row 0
-                // r6-r9: Row 1
-                // r10-r12, lr: Row 2
-                "ldr  r0, [sp, #8]",
-                "ldmia r0, {{r2-r12, lr}}",
+                // Store initial pointers and counter
+                "str     {rk}, [sp, #0]",
+                "mov     r0, #12",
+                "str     r0, [sp, #4]",
+                "str     {st}, [sp, #8]",
+
+                // Load 12-word state into registers
+                // r2-r5: Row 0 (A[0,0]-A[3,0])
+                // r6-r9: Row 1 (A[0,1]-A[3,1])
+                // r10-r12, lr: Row 2 (A[0,2]-A[3,2])
+                "ldr     r0, [sp, #8]",
+                "ldmia   r0, {{r2-r12, lr}}",
 
                 ".p2align 2",
                 "0:",
-                // === θ step ===
+
+                // === θ (Theta) step ===
                 // P[x] = A[x,0] ^ A[x,1] ^ A[x,2]
-                "eor  r0, r2, r6",  "eor  r0, r0, r10", // r0 = P0
-                "eor  r1, r3, r7",  "eor  r1, r1, r11", // r1 = P1
-                "push {{r0, r1}}",                      // Save P0, P1 to stack
-                "eor  r0, r4, r8",  "eor  r0, r0, r12", // r0 = P2
-                "eor  r1, r5, r9",  "eor  r1, r1, lr",  // r1 = P3
+                "eor     r0, r2, r6",   "eor r0, r0, r10",  // r0 = P0
+                "eor     r1, r3, r7",   "eor r1, r1, r11",  // r1 = P1
+                "push    {{r0, r1}}",                       // Save P0, P1
+                "eor     r0, r4, r8",   "eor r0, r0, r12",  // r0 = P2
+                "eor     r1, r5, r9",   "eor r1, r1, lr",   // r1 = P3
 
-                // E[x] = (P[x-1] ^ rot(P[x-1], 9)).rot(5)
+                // E[x] = rot(P[x-1], 5) ^ rot(P[x-1], 14)
+                // Note: (P ^ rot(P, 9)).rot(5) == rot(P, 5) ^ rot(P, 14)
 
-                // E0 depends on P3 (r1)
-                "eor  r1, r1, r1, ror #23", "ror r1, r1, #27",
-                "eor  r2, r2, r1", "eor  r6, r6, r1", "eor  r10, r10, r1",
+                // E0: depends on P3 (r1)
+                "eor     r1, r1, r1, ror #23",
+                "ror     r1, r1, #27",
+                "eor     r2, r2, r1",   "eor r6, r6, r1",   "eor r10, r10, r1",
 
-                // E1 depends on P0 (stack offset 0)
-                "ldr  r1, [sp, #0]",
-                "eor  r1, r1, r1, ror #23", "ror r1, r1, #27",
-                "eor  r3, r3, r1",  "eor  r7, r7, r1",  "eor  r11, r11, r1",
+                // E1: depends on P0 (stack offset 0)
+                "ldr     r1, [sp, #0]",
+                "eor     r1, r1, r1, ror #23",
+                "ror     r1, r1, #27",
+                "eor     r3, r3, r1",   "eor r7, r7, r1",   "eor r11, r11, r1",
 
-                // E2 depends on P1 (stack offset 4)
-                "ldr  r1, [sp, #4]",
-                "eor  r1, r1, r1, ror #23", "ror r1, r1, #27",
-                "eor  r4, r4, r1",  "eor  r8, r8, r1",  "eor  r12, r12, r1",
+                // E2: depends on P1 (stack offset 4)
+                "ldr     r1, [sp, #4]",
+                "eor     r1, r1, r1, ror #23",
+                "ror     r1, r1, #27",
+                "eor     r4, r4, r1",   "eor r8, r8, r1",   "eor r12, r12, r1",
 
-                // E3 depends on P2 (r0)
-                "eor  r0, r0, r0, ror #23",  "ror r0, r0, #27",
-                "eor  r5, r5, r0",  "eor  r9, r9, r0",  "eor  lr, lr, r0",
+                // E3: depends on P2 (r0)
+                "eor     r0, r0, r0, ror #23",
+                "ror     r0, r0, #27",
+                "eor     r5, r5, r0",   "eor r9, r9, r0",   "eor lr, lr, r0",
 
-                "add  sp, sp, #8",                      // Clean P0, P1 from stack
+                "add     sp, sp, #8",                       // Discard P0, P1
 
-                // === ρ West step ===
-                // Row 1: cyclic shift right 1
-                "mov  r0, r9", "mov  r9, r8", "mov  r8, r7", "mov  r7, r6", "mov  r6, r0",
-                // Row 2: bit rotation 11
-                "ror  r10, r10, #21", "ror  r11, r11, #21", "ror  r12, r12, #21", "ror  lr, lr, #21",
+                // === ρ (Rho) West step ===
+                // A[x,1] = A[x-1,1] (Cyclic shift Row 1)
+                "mov     r0, r9",
+                "mov     r9, r8",
+                "mov     r8, r7",
+                "mov     r7, r6",
+                "mov     r6, r0",
 
-                // === ι step ===
-                "ldr  r0, [sp, #0]",                    // load rk pointer
-                "ldr  r1, [r0], #4",                    // load rc and increment rk
-                "str  r0, [sp, #0]",                    // save rk pointer
-                "eor  r2, r2, r1",
+                // A[x,2] = rot(A[x,2], 11)
+                "ror     r10, r10, #21",
+                "ror     r11, r11, #21",
+                "ror     r12, r12, #21",
+                "ror     lr, lr, #21",
 
-                // === χ step ===
-                "bic  r0, r10, r6",  "eor  r2, r2, r0",  "bic  r0, r2, r10",  "eor  r6, r6, r0",  "bic  r0, r6, r2",   "eor  r10, r10, r0",
-                "bic  r0, r11, r7",  "eor  r3, r3, r0",  "bic  r0, r3, r11",  "eor  r7, r7, r0",  "bic  r0, r7, r3",   "eor  r11, r11, r0",
-                "bic  r0, r12, r8",  "eor  r4, r4, r0",  "bic  r0, r4, r12",  "eor  r8, r8, r0",  "bic  r0, r8, r4",   "eor  r12, r12, r0",
-                "bic  r0, lr, r9",   "eor  r5, r5, r0",  "bic  r0, r5, lr",   "eor  r9, r9, r0",  "bic  r0, r9, r5",   "eor  lr, lr, r0",
+                // === ι (Iota) step ===
+                "ldr     r0, [sp, #0]",                    // Load rk pointer
+                "ldr     r1, [r0], #4",                    // Load RC and increment
+                "str     r0, [sp, #0]",                    // Save rk pointer
+                "eor     r2, r2, r1",                      // A[0,0] ^= RC
 
-                // === ρ East step ===
-                // Row 1: bit rotation 1
-                "ror  r6, r6, #31", "ror  r7, r7, #31", "ror  r8, r8, #31", "ror  r9, r9, #31",
-                // Row 2: cyclic shift right 2 + bit rotation 8
-                "mov  r0, r10", "mov  r1, r11", "mov  r10, r12", "mov  r11, lr", "mov  r12, r0", "mov  lr, r1",
-                "ror  r10, r10, #24", "ror  r11, r11, #24", "ror  r12, r12, #24", "ror  lr, lr, #24",
+                // === χ (Chi) step ===
+                // A[x,y] ^= (~A[x,y+1]) & A[x,y+2]
+                "bic     r0, r10, r6",  "eor r2, r2, r0",
+                "bic     r0, r2, r10",  "eor r6, r6, r0",
+                "bic     r0, r6, r2",   "eor r10, r10, r0",
 
-                "ldr  r0, [sp, #4]",                    // load counter
-                "subs r0, r0, #1",
-                "str  r0, [sp, #4]",                    // save counter
-                "bne  0b",
+                "bic     r0, r11, r7",  "eor r3, r3, r0",
+                "bic     r0, r3, r11",  "eor r7, r7, r0",
+                "bic     r0, r7, r3",   "eor r11, r11, r0",
 
-                "ldr  r0, [sp, #8]",                    // load initial st pointer
-                "stmia r0, {{r2-r12, lr}}",             // Save back state
+                "bic     r0, r12, r8",  "eor r4, r4, r0",
+                "bic     r0, r4, r12",  "eor r8, r8, r0",
+                "bic     r0, r8, r4",   "eor r12, r12, r0",
 
-                "add  sp, sp, #12",
-                "pop  {{r4-r11, lr}}",                  // Restore and return
+                "bic     r0, lr, r9",   "eor r5, r5, r0",
+                "bic     r0, r5, lr",   "eor r9, r9, r0",
+                "bic     r0, r9, r5",   "eor lr, lr, r0",
+
+                // === ρ (Rho) East step ===
+                // A[x,1] = rot(A[x,1], 1)
+                "ror     r6, r6, #31",
+                "ror     r7, r7, #31",
+                "ror     r8, r8, #31",
+                "ror     r9, r9, #31",
+
+                // A[x,2] = rot(A[x-2,2], 8)
+                "mov     r0, r10",
+                "mov     r1, r11",
+                "mov     r10, r12",
+                "mov     r11, lr",
+                "mov     r12, r0",
+                "mov     lr, r1",
+                "ror     r10, r10, #24",
+                "ror     r11, r11, #24",
+                "ror     r12, r12, #24",
+                "ror     lr, lr, #24",
+
+                // Loop control
+                "ldr     r0, [sp, #4]",
+                "subs    r0, r0, #1",
+                "str     r0, [sp, #4]",
+                "bne     0b",
+
+                // Store state back
+                "ldr     r0, [sp, #8]",
+                "stmia   r0, {{r2-r12, lr}}",
+
+                "add     sp, sp, #12",
+                "pop     {{r4-r11, lr}}",
 
                 rk = in(reg) rkeys,
                 st = in(reg) st_ptr,

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -4,14 +4,15 @@ use core::arch::asm;
 
 #[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
 impl Xoodoo {
+    /// Optimized Xoodoo permutation for ARMv7-M (Thumb-2).
+    /// This version keeps Plane A and Plane B in registers (8 total) to maximize speed
+    /// while keeping register pressure low enough for reliable compilation on all
+    /// Thumb-2 targets. Plane C is handled via memory operations to save registers.
     #[allow(clippy::many_single_char_names)]
     pub fn permute(&mut self) {
-        let st_ptr = self.st.as_mut_ptr() as *mut u32;
-        let mut rkeys = ROUND_KEYS.as_ptr();
-        let rkeys_end = unsafe { rkeys.add(12) };
-        let c_ptr = unsafe { st_ptr.add(8) };
-
+        let rkeys = ROUND_KEYS.as_ptr();
         unsafe {
+            let st_ptr = self.st.as_mut_ptr() as *mut u32;
             let mut a0 = *st_ptr.add(0);
             let mut a1 = *st_ptr.add(1);
             let mut a2 = *st_ptr.add(2);
@@ -20,141 +21,104 @@ impl Xoodoo {
             let mut b1 = *st_ptr.add(5);
             let mut b2 = *st_ptr.add(6);
             let mut b3 = *st_ptr.add(7);
+            let mut rk = rkeys;
 
             asm!(
+                "mov r0, #12",           // Round counter
                 ".p2align 2",
-                "2:", // .Lround_loop
+                "3:",
+                "push {{r0}}",           // Save counter
 
                 // === THETA ===
-                // P0..3 are computed into the b registers temporarily,
-                // so we must save the real B plane to the stack.
-                // We use generic SUB/STR instead of PUSH {b0..b3} because
-                // rustc register allocation may not map b0..b3 to contiguous ascending registers.
-                "sub sp, sp, #16",
-                "str {b0}, [sp, #0]",
-                "str {b1}, [sp, #4]",
-                "str {b2}, [sp, #8]",
-                "str {b3}, [sp, #12]",
+                // Compute P_i = A_i ^ B_i ^ C_i. Must be done before applying Iota/Mixer.
+                "ldr r0, [{st}, #32]", "eor r0, r0, {a0}", "eor r0, r0, {b0}", "push {{r0}}", // P0 at [sp, #0]
+                "ldr r0, [{st}, #36]", "eor r0, r0, {a1}", "eor r0, r0, {b1}", "push {{r0}}", // P1 at [sp, #0], P0 at [sp, #4]
+                "ldr r0, [{st}, #40]", "eor r0, r0, {a2}", "eor r0, r0, {b2}", "push {{r0}}", // P2 at [sp, #0], P1 at [sp, #4], P0 at [sp, #8]
+                "ldr r0, [{st}, #44]", "eor r0, r0, {a3}", "eor r0, r0, {b3}",                 // r0 = P3
 
-                // Theta: Compute P in b0..b3
-                // P0 = a0 ^ b0 ^ c0
-                "ldr {t1}, [{c_ptr}, #0]",
-                "eor {b0}, {a0}, {b0}", "eor {b0}, {b0}, {t1}",
-                // P1
-                "ldr {t1}, [{c_ptr}, #4]",
-                "eor {b1}, {a1}, {b1}", "eor {b1}, {b1}, {t1}",
-                // P2
-                "ldr {t1}, [{c_ptr}, #8]",
-                "eor {b2}, {a2}, {b2}", "eor {b2}, {b2}, {t1}",
-                // P3
-                "ldr {t1}, [{c_ptr}, #12]",
-                "eor {b3}, {a3}, {b3}", "eor {b3}, {b3}, {t1}",
+                // --- IOTA ---
+                // Load Round Constant and apply to a0.
+                "ldr r1, [{rk}], #4",
+                "eor {a0}, {a0}, r1",
 
-                // Theta: Compute E. E0 = P3.rotr(27) ^ P3.rotr(18)
-                "ror {t1}, {b2}, #27", "eor {t1}, {t1}, {b2}, ror #18", // t1 = E3
-                "ror {t2}, {b1}, #27", "eor {t2}, {t2}, {b1}, ror #18", // t2 = E2
-                "ror {b1}, {b0}, #27", "eor {b1}, {b1}, {b0}, ror #18", // b1 = E1 (P0 is now consumed)
-                "ror {b2}, {b3}, #27", "eor {b2}, {b2}, {b3}, ror #18", // b2 = E0 (P3 is now consumed)
+                // Apply Mixer: E_i = P_{i-1}.rot(5) ^ P_{i-1}.rot(14)
+                // rot(5) = ROR 27, rot(14) = ROR 18
+                "ror r1, r0, #27", "eor r1, r1, r0, ror #18", // r1 = E0 (from P3 in r0)
+                "eor {a0}, {a0}, r1", "eor {b0}, {b0}, r1",
+                "ldr r0, [{st}, #32]", "eor r0, r0, r1", "str r0, [{st}, #32]",
 
-                // Apply E to A completely in registers
-                "eor {a0}, {a0}, {b2}",
-                "eor {a1}, {a1}, {b1}",
-                "eor {a2}, {a2}, {t2}",
-                "eor {a3}, {a3}, {t1}",
+                "ldr r0, [sp, #8]",      // P0
+                "ror r1, r0, #27", "eor r1, r1, r0, ror #18", // r1 = E1
+                "eor {a1}, {a1}, r1", "eor {b1}, {b1}, r1",
+                "ldr r0, [{st}, #36]", "eor r0, r0, r1", "str r0, [{st}, #36]",
 
-                // Apply E to B (which currently lives on the stack)
-                "ldr {b0}, [sp, #0]", "eor {b0}, {b0}, {b2}", "str {b0}, [sp, #0]",
-                "ldr {b0}, [sp, #4]", "eor {b0}, {b0}, {b1}", "str {b0}, [sp, #4]",
-                "ldr {b0}, [sp, #8]", "eor {b0}, {b0}, {t2}", "str {b0}, [sp, #8]",
-                "ldr {b0}, [sp, #12]","eor {b0}, {b0}, {t1}", "str {b0}, [sp, #12]",
+                "ldr r0, [sp, #4]",      // P1
+                "ror r1, r0, #27", "eor r1, r1, r0, ror #18", // r1 = E2
+                "eor {a2}, {a2}, r1", "eor {b2}, {b2}, r1",
+                "ldr r0, [{st}, #40]", "eor r0, r0, r1", "str r0, [{st}, #40]",
 
-                // Apply E to C (lives in main `st` array)
-                "ldr {b0}, [{c_ptr}, #0]", "eor {b0}, {b0}, {b2}", "str {b0}, [{c_ptr}, #0]",
-                "ldr {b0}, [{c_ptr}, #4]", "eor {b0}, {b0}, {b1}", "str {b0}, [{c_ptr}, #4]",
-                "ldr {b0}, [{c_ptr}, #8]", "eor {b0}, {b0}, {t2}", "str {b0}, [{c_ptr}, #8]",
-                "ldr {b0}, [{c_ptr}, #12]","eor {b0}, {b0}, {t1}", "str {b0}, [{c_ptr}, #12]",
+                "ldr r0, [sp, #0]",      // P2
+                "ror r1, r0, #27", "eor r1, r1, r0, ror #18", // r1 = E3
+                "eor {a3}, {a3}, r1", "eor {b3}, {b3}, r1",
+                "ldr r0, [{st}, #44]", "eor r0, r0, r1", "str r0, [{st}, #44]",
+
+                "add sp, sp, #12",       // Clean P results
 
                 // === RHO WEST ===
-                // B is shifted Left by 1 = Right by 31.
-                // We load B from stack with the column-shifted registry mapping:
-                // Old B3 goes to New B0, Old B0 to New B1, etc.
-                "ldr {b1}, [sp, #0]", "ror {b1}, {b1}, #31",
-                "ldr {b2}, [sp, #4]", "ror {b2}, {b2}, #31",
-                "ldr {b3}, [sp, #8]", "ror {b3}, {b3}, #31",
-                "ldr {b0}, [sp, #12]","ror {b0}, {b0}, #31",
-                // We purposely DO NOT free the sp stack layer here,
-                // so we can seamlessly reuse it as tmp scratch for Chi!
+                "mov r0, {b3}", "mov {b3}, {b2}", "mov {b2}, {b1}", "mov {b1}, {b0}", "mov {b0}, r0",
+                "ldr r0, [{st}, #32]", "ror r0, r0, #21", "str r0, [{st}, #32]",
+                "ldr r0, [{st}, #36]", "ror r0, r0, #21", "str r0, [{st}, #36]",
+                "ldr r0, [{st}, #40]", "ror r0, r0, #21", "str r0, [{st}, #40]",
+                "ldr r0, [{st}, #44]", "ror r0, r0, #21", "str r0, [{st}, #44]",
 
-                // === IOTA ===
-                "ldr {t1}, [{rkeys}], #4", // Load Round key & auto increment
-                "eor {a0}, {a0}, {t1}",
+                // === CHI ===
+                // Column 0
+                "mov r1, {a0}", "push {{{b0}}}",
+                "ldr r0, [{st}, #32]", "bic r0, r0, {b0}", "eor {a0}, {a0}, r0",
+                "ldr r0, [{st}, #32]", "bic r0, r1, r0", "eor {b0}, {b0}, r0",
+                "pop {{r0}}", "bic r0, r0, r1",
+                "ldr r1, [{st}, #32]", "eor r0, r0, r1", "str r0, [{st}, #32]",
 
-                // === CHI and RHO EAST (combined) ===
-                // To minimize scratch register dependencies securely, we process columns one by one
-                // and use the allocated stack layer to temporarily hold `tmpA` across the calculations.
+                // Column 1
+                "mov r1, {a1}", "push {{{b1}}}",
+                "ldr r0, [{st}, #36]", "bic r0, r0, {b1}", "eor {a1}, {a1}, r0",
+                "ldr r0, [{st}, #36]", "bic r0, r1, r0", "eor {b1}, {b1}, r0",
+                "pop {{r0}}", "bic r0, r0, r1",
+                "ldr r1, [{st}, #36]", "eor r0, r0, r1", "str r0, [{st}, #36]",
 
-                // Col 0
-                "ldr {t1}, [{c_ptr}, #0]",
-                "ror {t1}, {t1}, #21", // t1 = C0
-                "bic {t2}, {t1}, {b0}", "eor {t2}, {a0}, {t2}", // t2 = tmpA0
-                "str {t2}, [sp, #0]", // Save tmpA0
-                "bic {t2}, {a0}, {t1}", "eor {t2}, {b0}, {t2}", // t2 = tmpB0
-                "bic {a0}, {b0}, {a0}", "eor {t1}, {t1}, {a0}", // t1 = tmpC0
-                "ror {t2}, {t2}, #31", "mov {b0}, {t2}", // rotB = 1L (31R), save B0
-                "ror {t1}, {t1}, #24", "str {t1}, [{c_ptr}, #8]", // rotC = 8L (24R), save to C2!
-                "ldr {a0}, [sp, #0]", // restore A0
+                // Column 2
+                "mov r1, {a2}", "push {{{b2}}}",
+                "ldr r0, [{st}, #40]", "bic r0, r0, {b2}", "eor {a2}, {a2}, r0",
+                "ldr r0, [{st}, #40]", "bic r0, r1, r0", "eor {b2}, {b2}, r0",
+                "pop {{r0}}", "bic r0, r0, r1",
+                "ldr r1, [{st}, #40]", "eor r0, r0, r1", "str r0, [{st}, #40]",
 
-                // Col 1
-                "ldr {t1}, [{c_ptr}, #4]",
-                "ror {t1}, {t1}, #21", // t1 = C1
-                "bic {t2}, {t1}, {b1}", "eor {t2}, {a1}, {t2}", // t2 = tmpA1
-                "str {t2}, [sp, #4]", // Save tmpA1
-                "bic {t2}, {a1}, {t1}", "eor {t2}, {b1}, {t2}", // t2 = tmpB1
-                "bic {a1}, {b1}, {a1}", "eor {t1}, {t1}, {a1}", // t1 = tmpC1
-                "ror {t2}, {t2}, #31", "mov {b1}, {t2}", // rotB, save B1
-                "ror {t1}, {t1}, #24", "str {t1}, [{c_ptr}, #12]", // rotC, save to C3!
-                "ldr {a1}, [sp, #4]", // restore A1
+                // Column 3
+                "mov r1, {a3}", "push {{{b3}}}",
+                "ldr r0, [{st}, #44]", "bic r0, r0, {b3}", "eor {a3}, {a3}, r0",
+                "ldr r0, [{st}, #44]", "bic r0, r1, r0", "eor {b3}, {b3}, r0",
+                "pop {{r0}}", "bic r0, r0, r1",
+                "ldr r1, [{st}, #44]", "eor r0, r0, r1", "str r0, [{st}, #44]",
 
-                // Col 2
-                "ldr {t1}, [{c_ptr}, #8]",
-                "ror {t1}, {t1}, #21", // t1 = C2
-                "bic {t2}, {t1}, {b2}", "eor {t2}, {a2}, {t2}", // t2 = tmpA2
-                "str {t2}, [sp, #8]", // Save tmpA2
-                "bic {t2}, {a2}, {t1}", "eor {t2}, {b2}, {t2}", // t2 = tmpB2
-                "bic {a2}, {b2}, {a2}", "eor {t1}, {t1}, {a2}", // t1 = tmpC2
-                "ror {t2}, {t2}, #31", "mov {b2}, {t2}", // rotB, save B2
-                "ror {t1}, {t1}, #24", "str {t1}, [{c_ptr}, #0]", // rotC, save to C0!
-                "ldr {a2}, [sp, #8]", // restore A2
+                // === RHO EAST ===
+                "ror {b0}, {b0}, #31", "ror {b1}, {b1}, #31", "ror {b2}, {b2}, #31", "ror {b3}, {b3}, #31",
+                "ldr r0, [{st}, #32]", "ldr r1, [{st}, #40]", "str r0, [{st}, #40]", "str r1, [{st}, #32]",
+                "ldr r0, [{st}, #36]", "ldr r1, [{st}, #44]", "str r0, [{st}, #44]", "str r1, [{st}, #36]",
+                "ldr r0, [{st}, #32]", "ror r0, r0, #24", "str r0, [{st}, #32]",
+                "ldr r0, [{st}, #36]", "ror r0, r0, #24", "str r0, [{st}, #36]",
+                "ldr r0, [{st}, #40]", "ror r0, r0, #24", "str r0, [{st}, #40]",
+                "ldr r0, [{st}, #44]", "ror r0, r0, #24", "str r0, [{st}, #44]",
 
-                // Col 3
-                "ldr {t1}, [{c_ptr}, #12]",
-                "ror {t1}, {t1}, #21", // t1 = C3
-                "bic {t2}, {t1}, {b3}", "eor {t2}, {a3}, {t2}", // t2 = tmpA3
-                "str {t2}, [sp, #12]", // Save tmpA3
-                "bic {t2}, {a3}, {t1}", "eor {t2}, {b3}, {t2}", // t2 = tmpB3
-                "bic {a3}, {b3}, {a3}", "eor {t1}, {t1}, {a3}", // t1 = tmpC3
-                "ror {t2}, {t2}, #31", "mov {b3}, {t2}", // rotB, save B3
-                "ror {t1}, {t1}, #24", "str {t1}, [{c_ptr}, #4]", // rotC, save to C1!
-                "ldr {a3}, [sp, #12]", // restore A3
+                "pop {{r0}}",            // Restore loop counter
+                "subs r0, #1",
+                "bne 3b",
 
-                "add sp, sp, #16", // Now we free the scratch stack correctly
-
-                "cmp {rkeys}, {rkeys_end}",
-                "bne 2b",
-
-                a0 = inout(reg) a0,
-                a1 = inout(reg) a1,
-                a2 = inout(reg) a2,
-                a3 = inout(reg) a3,
-                b0 = inout(reg) b0,
-                b1 = inout(reg) b1,
-                b2 = inout(reg) b2,
-                b3 = inout(reg) b3,
-                rkeys = inout(reg) rkeys,
-                rkeys_end = in(reg) rkeys_end,
-                c_ptr = in(reg) c_ptr,
-                t1 = out(reg) _,
-                t2 = out(reg) _,
+                st = in(reg) st_ptr,
+                rk = inout(reg) rk,
+                a0 = inout(reg) a0, a1 = inout(reg) a1, a2 = inout(reg) a2, a3 = inout(reg) a3,
+                b0 = inout(reg) b0, b1 = inout(reg) b1, b2 = inout(reg) b2, b3 = inout(reg) b3,
+                out("r0") _,
+                out("r1") _,
             );
 
             *st_ptr.add(0) = a0;
@@ -165,6 +129,7 @@ impl Xoodoo {
             *st_ptr.add(5) = b1;
             *st_ptr.add(6) = b2;
             *st_ptr.add(7) = b3;
+            let _ = rk;
         }
     }
 }

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -1,8 +1,8 @@
+#![cfg(all(target_arch = "arm", target_has_atomic = "32"))]
+
 use super::{Xoodoo, ROUND_KEYS};
-#[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
 use core::arch::asm;
 
-#[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
 impl Xoodoo {
     /// Optimized Xoodoo permutation for ARMv7-M (Thumb-2).
     #[allow(clippy::many_single_char_names)]

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -1,8 +1,13 @@
 use core::convert::TryInto;
 use zeroize::Zeroize;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(
+    target_arch = "x86_64",
+    all(target_arch = "arm", target_feature = "thumb2"),
+)))]
 mod impl_portable;
+#[cfg(all(target_arch = "arm", target_feature = "thumb2"))]
+mod impl_thumb2;
 #[cfg(target_arch = "x86_64")]
 mod impl_x86_64;
 

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -4,8 +4,11 @@ use zeroize::Zeroize;
 #[cfg(not(any(
     target_arch = "x86_64",
     all(target_arch = "arm", target_has_atomic = "32"),
+    all(target_arch = "arm", not(target_has_atomic = "32")),
 )))]
 mod impl_portable;
+#[cfg(all(target_arch = "arm", not(target_has_atomic = "32")))]
+mod impl_thumb1;
 #[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
 mod impl_thumb2;
 #[cfg(target_arch = "x86_64")]

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -3,10 +3,10 @@ use zeroize::Zeroize;
 
 #[cfg(not(any(
     target_arch = "x86_64",
-    all(target_arch = "arm", target_feature = "thumb2"),
+    all(target_arch = "arm", target_has_atomic = "32"),
 )))]
 mod impl_portable;
-#[cfg(all(target_arch = "arm", target_feature = "thumb2"))]
+#[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
 mod impl_thumb2;
 #[cfg(target_arch = "x86_64")]
 mod impl_x86_64;

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -11,6 +11,7 @@ const ROUND_KEYS: [u32; 12] = [
 ];
 
 #[derive(Clone, Debug)]
+#[repr(align(4))]
 pub struct Xoodoo {
     st: [u8; 48],
 }
@@ -57,7 +58,7 @@ impl Xoodoo {
         for st_word in &mut st_words {
             *st_word = (*st_word).to_le()
         }
-        self.from_words(&st_words);
+        self.init_from_words(st_words);
     }
 
     #[cfg(target_endian = "little")]

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -3,20 +3,12 @@ use zeroize::Zeroize;
 
 #[cfg(not(any(
     target_arch = "x86_64",
-    all(target_arch = "arm", target_endian = "little"),
+    all(target_arch = "arm", target_endian = "little", any(thumb1, thumb2)),
 )))]
 mod impl_portable;
-#[cfg(all(
-    target_arch = "arm",
-    target_endian = "little",
-    not(target_has_atomic = "32"),
-))]
+#[cfg(all(target_arch = "arm", target_endian = "little", thumb1))]
 mod impl_thumb1;
-#[cfg(all(
-    target_arch = "arm",
-    target_endian = "little",
-    target_has_atomic = "32",
-))]
+#[cfg(all(target_arch = "arm", target_endian = "little", thumb2))]
 mod impl_thumb2;
 #[cfg(target_arch = "x86_64")]
 mod impl_x86_64;

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -3,13 +3,20 @@ use zeroize::Zeroize;
 
 #[cfg(not(any(
     target_arch = "x86_64",
-    all(target_arch = "arm", target_has_atomic = "32"),
-    all(target_arch = "arm", not(target_has_atomic = "32")),
+    all(target_arch = "arm", target_endian = "little"),
 )))]
 mod impl_portable;
-#[cfg(all(target_arch = "arm", not(target_has_atomic = "32")))]
+#[cfg(all(
+    target_arch = "arm",
+    target_endian = "little",
+    not(target_has_atomic = "32"),
+))]
 mod impl_thumb1;
-#[cfg(all(target_arch = "arm", target_has_atomic = "32"))]
+#[cfg(all(
+    target_arch = "arm",
+    target_endian = "little",
+    target_has_atomic = "32",
+))]
 mod impl_thumb2;
 #[cfg(target_arch = "x86_64")]
 mod impl_x86_64;


### PR DESCRIPTION
This PR is intended for informational purposes.  
I use this on Cortex-M3 and have added a bit of optimization.

~~~bash
cross test --target armv7-unknown-linux-gnueabihf
~~~

This works fine for running tests on thumb1 (it doesn’t compile as thumb2 for some reason).
The optimization only affects load/store operations.

For thumb2, I compared the output on an Arm Cortex-M3 device against the portable version, but did not run the test suite.

This PR is essentially an FYI that I use this.
If the maintainer prefers not to upstream it and would rather not keep this PR open, feel free to close it.