### PR TITLE
Modernize crate to Rust 2024 and transition to unconditional `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["no-std", "cryptography", "wasm"]
 
 [features]
 default = ["std"]
-std = []
+std = ["zeroize/alloc"]
 
 [dependencies]
-zeroize = "1.8"
+zeroize = { version = "1.8", default-features = false }
 
 [dev-dependencies]
 benchmark-simple = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/jedisct1/rust-xoodyak"
 categories = ["no-std", "cryptography", "wasm"]
 
 [features]
-default = ["std"]
-std = ["zeroize/alloc"]
+default = []
+alloc = ["zeroize/alloc"]
 
 [dependencies]
 zeroize = { version = "1.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xoodyak"
 version = "0.8.4"
 authors = ["Frank Denis <github@pureftpd.org>"]
-edition = "2018"
+edition = "2024"
 description = "Xoodyak / Xoodoo - A versatile cryptographic scheme that can be used for hashing, encryption, MAC computation and authenticated encryption."
 readme = "README.md"
 keywords = ["crypto", "xoodyak", "xoodoo", "cyclist"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    println!("cargo:rustc-check-cfg=cfg(thumb1, thumb2)");
+
+    if target.contains("thumbv7")
+        || target.contains("thumbv8m.main")
+        || target.contains("thumbv8r")
+        || target.contains("armv7")
+        || target.contains("armv8")
+        || target.contains("armv9")
+    {
+        println!("cargo:rustc-cfg=thumb2");
+    } else if target.contains("thumbv4")
+        || target.contains("thumbv5")
+        || target.contains("thumbv6")
+        || target.contains("thumbv8m.base")
+        || target.contains("armv4")
+        || target.contains("armv5")
+        || target.contains("armv6")
+    {
+        println!("cargo:rustc-cfg=thumb1");
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     KeyRequired,
     TagMismatch,
 }
+impl core::error::Error for Error {}
+
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,10 +7,6 @@ pub enum Error {
     KeyRequired,
     TagMismatch,
 }
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
-
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod error;
 mod xoodoo;

--- a/src/test.rs
+++ b/src/test.rs
@@ -177,3 +177,26 @@ fn test_aead_detached() {
         .unwrap();
     assert_eq!(&m2[..], &m[..]);
 }
+
+#[cfg(feature = "alloc")]
+#[test]
+fn test_alloc_to_vec() {
+    let nonce = [0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    let mut st = XoodyakKeyed::new(b"key", Some(&nonce), None, None).unwrap();
+    let st0 = st.clone();
+    let m = b"message";
+    
+    let c = st.encrypt_to_vec(m).unwrap();
+    let mut st = st0.clone();
+    let m2 = st.decrypt_to_vec(&c).unwrap();
+    assert_eq!(m, m2.as_slice());
+
+    let mut st = st0.clone();
+    st.absorb(b"ad");
+    let c2 = st.aead_encrypt_to_vec(Some(m)).unwrap();
+    let mut st = st0.clone();
+    st.absorb(b"ad");
+    let m3 = st.aead_decrypt_to_vec(&c2).unwrap();
+    assert_eq!(m, m3.as_slice());
+}
+

--- a/src/xoodoo/impl_riscv32.rs
+++ b/src/xoodoo/impl_riscv32.rs
@@ -1,0 +1,203 @@
+use core::arch::asm;
+
+use super::{Xoodoo, ROUND_KEYS};
+
+impl Xoodoo {
+    /// Dynamically binds the 12-word state to registers for optimal compiler allocation.
+    #[allow(clippy::many_single_char_names)]
+    pub fn permute(&mut self) {
+        let st_words = unsafe { &mut *(self.st.as_mut_ptr() as *mut [u32; 12]) };
+        let rkeys = ROUND_KEYS.as_ptr();
+        let rkeys_end = unsafe { rkeys.add(12) };
+        let rk = rkeys;
+
+        unsafe {
+            asm!(
+                "0:",
+                // === θ (Theta) step ===
+                "xor     t0, {s0}, {s4}",
+                "xor     t0, t0, {s8}",          // t0 = P0
+                "xor     t1, {s1}, {s5}",
+                "xor     t1, t1, {s9}",          // t1 = P1
+                "xor     t2, {s2}, {s6}",
+                "xor     t2, t2, {s10}",         // t2 = P2
+                "xor     t3, {s3}, {s7}",
+                "xor     t3, t3, {s11}",         // t3 = P3
+
+                // Compute and apply E0 to Column 0
+                "slli    t4, t3, 5",
+                "srli    t5, t3, 27",
+                "or      t4, t4, t5",
+                "slli    t5, t3, 14",
+                "srli    t6, t3, 18",
+                "or      t5, t5, t6",
+                "xor     t4, t4, t5",
+                "xor     {s0}, {s0}, t4",
+                "xor     {s4}, {s4}, t4",
+                "xor     {s8}, {s8}, t4",
+
+                // Compute and apply E1 to Column 1
+                "slli    t4, t0, 5",
+                "srli    t5, t0, 27",
+                "or      t4, t4, t5",
+                "slli    t5, t0, 14",
+                "srli    t6, t0, 18",
+                "or      t5, t5, t6",
+                "xor     t4, t4, t5",
+                "xor     {s1}, {s1}, t4",
+                "xor     {s5}, {s5}, t4",
+                "xor     {s9}, {s9}, t4",
+
+                // Compute and apply E2 to Column 2
+                "slli    t4, t1, 5",
+                "srli    t5, t1, 27",
+                "or      t4, t4, t5",
+                "slli    t5, t1, 14",
+                "srli    t6, t1, 18",
+                "or      t5, t5, t6",
+                "xor     t4, t4, t5",
+                "xor     {s2}, {s2}, t4",
+                "xor     {s6}, {s6}, t4",
+                "xor     {s10}, {s10}, t4",
+
+                // Compute and apply E3 to Column 3
+                "slli    t4, t2, 5",
+                "srli    t5, t2, 27",
+                "or      t4, t4, t5",
+                "slli    t5, t2, 14",
+                "srli    t6, t2, 18",
+                "or      t5, t5, t6",
+                "xor     t4, t4, t5",
+                "xor     {s3}, {s3}, t4",
+                "xor     {s7}, {s7}, t4",
+                "xor     {s11}, {s11}, t4",
+
+                // === ρ (Rho) west step ===
+                "mv      t4, {s7}",
+                "mv      {s7}, {s6}",
+                "mv      {s6}, {s5}",
+                "mv      {s5}, {s4}",
+                "mv      {s4}, t4",
+
+                "slli    t4, {s8}, 11",
+                "srli    {s8}, {s8}, 21",
+                "or      {s8}, {s8}, t4",
+
+                "slli    t4, {s9}, 11",
+                "srli    {s9}, {s9}, 21",
+                "or      {s9}, {s9}, t4",
+
+                "slli    t4, {s10}, 11",
+                "srli    {s10}, {s10}, 21",
+                "or      {s10}, {s10}, t4",
+
+                "slli    t4, {s11}, 11",
+                "srli    {s11}, {s11}, 21",
+                "or      {s11}, {s11}, t4",
+
+                // === ι (Iota) step ===
+                "lw      t4, 0({rk})",
+                "addi    {rk}, {rk}, 4",
+                "xor     {s0}, {s0}, t4",
+
+                // === χ (Chi) step ===
+                "not     t4, {s4}",
+                "and     t4, t4, {s8}",
+                "xor     {s0}, {s0}, t4",
+                "not     t4, {s8}",
+                "and     t4, t4, {s0}",
+                "xor     {s4}, {s4}, t4",
+                "not     t4, {s0}",
+                "and     t4, t4, {s4}",
+                "xor     {s8}, {s8}, t4",
+
+                "not     t4, {s5}",
+                "and     t4, t4, {s9}",
+                "xor     {s1}, {s1}, t4",
+                "not     t4, {s9}",
+                "and     t4, t4, {s1}",
+                "xor     {s5}, {s5}, t4",
+                "not     t4, {s1}",
+                "and     t4, t4, {s5}",
+                "xor     {s9}, {s9}, t4",
+
+                "not     t4, {s6}",
+                "and     t4, t4, {s10}",
+                "xor     {s2}, {s2}, t4",
+                "not     t4, {s10}",
+                "and     t4, t4, {s2}",
+                "xor     {s6}, {s6}, t4",
+                "not     t4, {s2}",
+                "and     t4, t4, {s6}",
+                "xor     {s10}, {s10}, t4",
+
+                "not     t4, {s7}",
+                "and     t4, t4, {s11}",
+                "xor     {s3}, {s3}, t4",
+                "not     t4, {s11}",
+                "and     t4, t4, {s3}",
+                "xor     {s7}, {s7}, t4",
+                "not     t4, {s3}",
+                "and     t4, t4, {s7}",
+                "xor     {s11}, {s11}, t4",
+
+                // === ρ (Rho) east step ===
+                "slli    t4, {s4}, 1",
+                "srli    {s4}, {s4}, 31",
+                "or      {s4}, {s4}, t4",
+
+                "slli    t4, {s5}, 1",
+                "srli    {s5}, {s5}, 31",
+                "or      {s5}, {s5}, t4",
+
+                "slli    t4, {s6}, 1",
+                "srli    {s6}, {s6}, 31",
+                "or      {s6}, {s6}, t4",
+
+                "slli    t4, {s7}, 1",
+                "srli    {s7}, {s7}, 31",
+                "or      {s7}, {s7}, t4",
+
+                "slli    t4, {s8}, 8",
+                "srli    t5, {s8}, 24",
+                "or      t5, t5, t4",
+
+                "slli    t4, {s9}, 8",
+                "srli    t6, {s9}, 24",
+                "or      t6, t6, t4",
+
+                "slli    t4, {s10}, 8",
+                "srli    {s8}, {s10}, 24",
+                "or      {s8}, {s8}, t4",
+
+                "slli    t4, {s11}, 8",
+                "srli    {s9}, {s11}, 24",
+                "or      {s9}, {s9}, t4",
+
+                "mv      {s10}, t5",
+                "mv      {s11}, t6",
+
+                // === Loop check ===
+                "bne     {rk}, {rk_end}, 0b",
+
+                s0 = inout(reg) st_words[0],
+                s1 = inout(reg) st_words[1],
+                s2 = inout(reg) st_words[2],
+                s3 = inout(reg) st_words[3],
+                s4 = inout(reg) st_words[4],
+                s5 = inout(reg) st_words[5],
+                s6 = inout(reg) st_words[6],
+                s7 = inout(reg) st_words[7],
+                s8 = inout(reg) st_words[8],
+                s9 = inout(reg) st_words[9],
+                s10 = inout(reg) st_words[10],
+                s11 = inout(reg) st_words[11],
+                rk = inout(reg) rk => _,
+                rk_end = in(reg) rkeys_end,
+                out("t0") _, out("t1") _, out("t2") _, out("t3") _,
+                out("t4") _, out("t5") _, out("t6") _,
+                options(nostack),
+            );
+        }
+    }
+}

--- a/src/xoodoo/impl_thumb1.rs
+++ b/src/xoodoo/impl_thumb1.rs
@@ -1,0 +1,276 @@
+use core::arch::asm;
+
+use super::{Xoodoo, ROUND_KEYS};
+
+impl Xoodoo {
+    /// Optimized Xoodoo permutation for ARMv6-M (Cortex-M0).
+    #[allow(clippy::many_single_char_names)]
+    pub fn permute(&mut self) {
+        let rkeys = ROUND_KEYS.as_ptr();
+        unsafe {
+            let st_ptr = self.st.as_mut_ptr() as *mut u32;
+
+            asm!(
+                // Preserve callee-saved registers
+                "push    {{r4-r7, lr}}",
+                "mov     r0, r8",
+                "mov     r1, r9",
+                "mov     r2, r10",
+                "mov     r3, r11",
+                "push    {{r0-r3}}",
+                "mov     r0, r12",
+                "push    {{r0}}",
+
+                // Stack frame: [0]=A30, [4]=rk, [8]=counter, [12]=st
+                "push    {{{st}}}",                 // [sp, #12]:st
+                "movs    r0, #12",
+                "push    {{r0}}",                    // [sp, #8]:counter
+                "push    {{{rk}}}",                  // [sp, #4]:rk
+                "movs    r0, #0",
+                "push    {{r0}}",                    // [sp, #0]:A30 placeholder
+
+                // Load initial state
+                // Row 0: r3, r8, r9, [sp, #0]   (A[0,0], A[1,0], A[2,0], A[3,0])
+                // Row 1: r10, r11, r12, lr     (A[0,1], A[1,1], A[2,1], A[3,1])
+                // Row 2: r4, r5, r6, r7        (A[0,2], A[1,2], A[2,2], A[3,2])
+                "mov     r0, {st}",
+                "ldm     r0!, {{r3, r4, r5, r6}}",
+                "mov     r8, r4",
+                "mov     r9, r5",
+                "str     r6, [sp, #0]",
+                "ldm     r0!, {{r4, r5, r6, r7}}",
+                "mov     r10, r4",
+                "mov     r11, r5",
+                "mov     r12, r6",
+                "mov     lr, r7",
+                "ldm     r0!, {{r4, r5, r6, r7}}",
+
+                ".p2align 2",
+                "0:",
+
+                // === θ (Theta) step ===
+                // P[x] = A[x,0] ^ A[x,1] ^ A[x,2]
+                // E[x] = rot(P[x-1], 5) ^ rot(P[x-1], 14)
+
+                // --- Calculate E0 from P3 ---
+                // P3 = A[3,0] ^ A[3,1] ^ A[3,2]
+                "ldr     r0, [sp, #0]",
+                "mov     r1, lr",
+                "eors    r0, r1",
+                "eors    r0, r7",                   // r0 = P3
+                "mov     r1, r0",
+                "movs    r2, #23",                  // rot 9
+                "rors    r1, r2",
+                "eors    r1, r0",
+                "movs    r2, #27",                  // rot 5
+                "rors    r1, r2",                   // r1 = E0
+
+                // Apply E0 to Col 0
+                "mov     r0, r3",                   // P0 calculation starts here
+                "mov     r2, r10",
+                "eors    r0, r2",
+                "eors    r0, r4",                   // r0 = P0
+                "eors    r3, r1",                   // A[0,0] ^= E0
+                "mov     r2, r10",
+                "eors    r2, r1",
+                "mov     r10, r2",                  // A[0,1] ^= E0
+                "eors    r4, r1",                   // A[0,2] ^= E0
+
+                // --- Calculate E1 from P0 ---
+                "mov     r1, r0",
+                "movs    r2, #23",
+                "rors    r1, r2",
+                "eors    r1, r0",
+                "movs    r2, #27",
+                "rors    r1, r2",               // r1 = E1
+
+                // Apply E1 to Col 1
+                "mov     r0, r8",                   // P1 calculation
+                "mov     r2, r11",
+                "eors    r0, r2",
+                "eors    r0, r5",               // r0 = P1
+                "mov     r2, r8",
+                "eors    r2, r1",
+                "mov     r8, r2",                   // A[1,0] ^= E1
+                "mov     r2, r11",
+                "eors    r2, r1",
+                "mov     r11, r2",                  // A[1,1] ^= E1
+                "eors    r5, r1",                   // A[1,2] ^= E1
+
+                // --- Calculate E2 from P1 ---
+                "mov     r1, r0",
+                "movs    r2, #23",
+                "rors    r1, r2",
+                "eors    r1, r0",
+                "movs    r2, #27",
+                "rors    r1, r2",               // r1 = E2
+
+                // Apply E2 to Col 2
+                "mov     r0, r9",                   // P2 calculation
+                "mov     r2, r12",
+                "eors    r0, r2",
+                "eors    r0, r6",               // r0 = P2
+                "mov     r2, r9",
+                "eors    r2, r1",
+                "mov     r9, r2",                   // A[2,0] ^= E2
+                "mov     r2, r12",
+                "eors    r2, r1",
+                "mov     r12, r2",                  // A[2,1] ^= E2
+                "eors    r6, r1",                   // A[2,2] ^= E2
+
+                // --- Calculate E3 from P2 ---
+                "mov     r1, r0",
+                "movs    r2, #23",
+                "rors    r1, r2",
+                "eors    r1, r0",
+                "movs    r2, #27",
+                "rors    r1, r2",               // r1 = E3
+
+                // Apply E3 to Col 3
+                "ldr     r0, [sp, #0]",
+                "eors    r0, r1",
+                "str     r0, [sp, #0]",             // A[3,0] ^= E3
+                "mov     r2, lr",
+                "eors    r2, r1",
+                "mov     lr, r2",                   // A[3,1] ^= E3
+                "eors    r7, r1",                   // A[3,2] ^= E3
+
+                // === ρ (Rho) West step ===
+                // A[x,1] = A[x-1,1] (Cyclic shift Row 1)
+                "mov     r0, lr",
+                "mov     lr, r12",
+                "mov     r12, r11",
+                "mov     r11, r10",
+                "mov     r10, r0",
+
+                // A[x,2] = rot(A[x,2], 11)
+                "movs    r0, #21",                  // rot 11
+                "rors    r4, r0",
+                "rors    r5, r0",
+                "rors    r6, r0",
+                "rors    r7, r0",
+
+                // === ι (Iota) step ===
+                // A[0,0] ^= RC
+                "ldr     r0, [sp, #4]",
+                "ldm     r0!, {{r1}}",
+                "str     r0, [sp, #4]",
+                "eors    r3, r1",
+
+                // === χ (Chi) step ===
+                // A[x,0] ^= (~A[x,1]) & A[x,2]
+                // A[x,1] ^= (~A[x,2]) & A[x,0]
+                // A[x,2] ^= (~A[x,0]) & A[x,1]
+
+                // x=0 (Col 0)
+                "mov     r1, r10",
+                "mov     r2, r4",
+                "bics    r2, r1",
+                "eors    r3, r2",                   // a0 = a0_new
+                "mov     r2, r3",
+                "bics    r2, r4",
+                "eors    r2, r1",
+                "mov     r10, r2",                  // a1 = a1_new
+                "bics    r2, r3",
+                "eors    r4, r2",                   // a2 = a2_new
+
+                // x=1 (Col 1)
+                "mov     r1, r11",
+                "mov     r2, r5",
+                "bics    r2, r1",
+                "mov     r0, r8",
+                "eors    r2, r0",
+                "mov     r8, r2",                   // a0 = a0_new
+                "bics    r2, r5",
+                "eors    r2, r1",
+                "mov     r11, r2",                  // a1 = a1_new
+                "mov     r0, r8",
+                "bics    r2, r0",
+                "eors    r5, r2",                   // a2 = a2_new
+
+                // x=2 (Col 2)
+                "mov     r1, r12",
+                "mov     r2, r6",
+                "bics    r2, r1",
+                "mov     r0, r9",
+                "eors    r2, r0",
+                "mov     r9, r2",                   // a0 = a0_new
+                "bics    r2, r6",
+                "eors    r2, r1",
+                "mov     r12, r2",                  // a1 = a1_new
+                "mov     r0, r9",
+                "bics    r2, r0",
+                "eors    r6, r2",                   // a2 = a2_new
+
+                // x=3 (Col 3)
+                "ldr     r0, [sp, #0]",
+                "mov     r1, lr",
+                "mov     r2, r7",
+                "bics    r2, r1",
+                "eors    r0, r2",
+                "str     r0, [sp, #0]",             // a0 = a0_new
+                "mov     r2, r0",
+                "bics    r2, r7",
+                "eors    r2, r1",
+                "mov     lr, r2",                   // a1 = a1_new
+                "bics    r2, r0",
+                "eors    r7, r2",                   // a2 = a2_new
+
+                // === ρ (Rho) East step ===
+                // A[x,1] = rot(A[x,1], 1)
+                "movs    r0, #31",                  // rot 1
+                "mov     r1, r10",  "rors r1, r0",  "mov r10, r1",
+                "mov     r1, r11",  "rors r1, r0",  "mov r11, r1",
+                "mov     r1, r12",  "rors r1, r0",  "mov r12, r1",
+                "mov     r1, lr",   "rors r1, r0",  "mov lr, r1",
+
+                // A[x,2] = rot(A[x-2,2], 8)
+                "movs    r0, #24",                  // rot 8
+                "rors    r4, r0",
+                "rors    r5, r0",
+                "rors    r6, r0",
+                "rors    r7, r0",
+                // Cyclic shift Row 2 by 2
+                "mov     r0, r4",   "mov r4, r6",   "mov r6, r0",
+                "mov     r0, r5",   "mov r5, r7",   "mov r7, r0",
+
+                // Loop control
+                "ldr     r0, [sp, #8]",
+                "subs    r0, r0, #1",
+                "str     r0, [sp, #8]",
+                "bne     0b",
+
+                // Save back state
+                "ldr     r0, [sp, #12]",
+                "stm     r0!, {{r3}}",
+                "mov     r1, r8",
+                "mov     r2, r9",
+                "ldr     r3, [sp, #0]",
+                "stm     r0!, {{r1-r3}}",
+                "mov     r1, r10",
+                "mov     r2, r11",
+                "mov     r3, r12",
+                "stm     r0!, {{r1-r3}}",
+                "mov     r1, lr",
+                "stm     r0!, {{r1, r4-r7}}",
+
+                // Restore registers
+                "pop     {{r0, r1, r2, r3}}",               // Discard frame
+                "pop     {{r0}}",
+                "mov     r12, r0",
+                "pop     {{r0-r3}}",
+                "mov     r8, r0",
+                "mov     r9, r1",
+                "mov     r10, r2",
+                "mov     r11, r3",
+                "pop     {{r4-r7}}",
+                "pop     {{r0}}",
+                "mov     lr, r0",
+
+                rk = in(reg) rkeys,
+                st = in(reg) st_ptr,
+                out("r0") _, out("r1") _, out("r2") _, out("r3") _,
+            );
+        }
+    }
+}

--- a/src/xoodoo/impl_thumb2.rs
+++ b/src/xoodoo/impl_thumb2.rs
@@ -1,0 +1,125 @@
+use core::arch::asm;
+
+use super::{Xoodoo, ROUND_KEYS};
+
+impl Xoodoo {
+    /// Highly optimized Xoodoo permutation for ARMv7-M (Thumb-2).
+    /// Uses all available registers to eliminate memory spills.
+    #[allow(clippy::many_single_char_names)]
+    pub fn permute(&mut self) {
+        let rkeys = ROUND_KEYS.as_ptr();
+        unsafe {
+            let st_ptr = self.st.as_mut_ptr() as *mut u32;
+
+            asm!(
+                // Save callee-saved registers
+                "push    {{r4-r11, lr}}",
+                // Stack frame: [sp, #4]=st, [sp, #0]=rk
+                "push    {{{st}}}",
+                "push    {{{rk}}}",
+                "mov     r1, #12",                // r1 = round counter
+
+                // Load 12-word state into registers
+                // r2-r5: Row 0 (A[0,0]-A[3,0])
+                // r6-r9: Row 1 (A[0,1]-A[3,1])
+                // r10-r12, lr: Row 2 (A[0,2]-A[3,2])
+                "ldr     r0, [sp, #4]",
+                "ldmia   r0, {{r2-r12, lr}}",
+
+                ".p2align 2",
+                "0:",
+
+                // === θ (Theta) step ===
+                // P[x] = A[x,0] ^ A[x,1] ^ A[x,2]
+                // OPTIMIZATION: "Parity Correction". Instead of storing P[x] on stack,
+                // we update columns sequentially. Original parity of a modified column
+                // is recovered by P_orig = P_updated ^ E_applied.
+
+                "eor     r0, r2, r6",   "eor r0, r0, r10",  // r0 = P0
+                "eor     r0, r0, r0, ror #23", "ror r0, r0, #27", // r0 = E1
+                "eor     r3, r3, r0",   "eor r7, r7, r0",   "eor r11, r11, r0", // Update Col 1
+
+                "eor     r0, r0, r3",   "eor r0, r0, r7",   "eor r0, r0, r11",  // r0 = P1
+                "eor     r0, r0, r0, ror #23", "ror r0, r0, #27", // r0 = E2
+                "eor     r4, r4, r0",   "eor r8, r8, r0",   "eor r12, r12, r0", // Update Col 2
+
+                "eor     r0, r0, r4",   "eor r0, r0, r8",   "eor r0, r0, r12",  // r0 = P2
+                "eor     r0, r0, r0, ror #23", "ror r0, r0, #27", // r0 = E3
+                "eor     r5, r5, r0",   "eor r9, r9, r0",   "eor lr, lr, r0",   // Update Col 3
+
+                "eor     r0, r0, r5",   "eor r0, r0, r9",   "eor r0, r0, lr",   // r0 = P3
+                "eor     r0, r0, r0, ror #23", "ror r0, r0, #27", // r0 = E0
+                "eor     r2, r2, r0",   "eor r6, r6, r0",   "eor r10, r10, r0", // Update Col 0
+
+                // === ρ (Rho) West step ===
+                // A[x,1] = A[x-1,1] (Cyclic shift Row 1)
+                "mov     r0, r9",
+                "mov     r9, r8",
+                "mov     r8, r7",
+                "mov     r7, r6",
+                "mov     r6, r0",
+
+                // A[x,2] = rot(A[x,2], 11)
+                "ror     r10, r10, #21",
+                "ror     r11, r11, #21",
+                "ror     r12, r12, #21",
+                "ror     lr, lr, #21",
+
+                // === ι (Iota) step ===
+                // A[0,0] = A[0,0] ^ RC
+                "ldr     r0, [sp, #0]",                    // Get rk_ptr
+                "add     r0, r0, #4",                      // Increment
+                "str     r0, [sp, #0]",                    // Save incremented pointer back
+                "ldr     r0, [r0, #-4]",                   // Load RC (post-incremented access)
+                "eor     r2, r2, r0",                      // A[0,0] ^= RC
+
+                // === χ (Chi) step ===
+                // A[x,y] ^= (~A[x,y+1]) & A[x,y+2]
+                "bic     r0, r10, r6",  "eor r2, r2, r0",
+                "bic     r0, r2, r10",  "eor r6, r6, r0",
+                "bic     r0, r6, r2",   "eor r10, r10, r0",
+                "bic     r0, r11, r7",  "eor r3, r3, r0",
+                "bic     r0, r3, r11",  "eor r7, r7, r0",
+                "bic     r0, r7, r3",   "eor r11, r11, r0",
+                "bic     r0, r12, r8",  "eor r4, r4, r0",
+                "bic     r0, r4, r12",  "eor r8, r8, r0",
+                "bic     r0, r8, r4",   "eor r12, r12, r0",
+                "bic     r0, lr, r9",   "eor r5, r5, r0",
+                "bic     r0, r5, lr",   "eor r9, r9, r0",
+                "bic     r0, r9, r5",   "eor lr, lr, r0",
+
+                // === ρ (Rho) East step ===
+                // A[x,1] = rot(A[x,1], 1)
+                "ror     r6, r6, #31",
+                "ror     r7, r7, #31",
+                "ror     r8, r8, #31",
+                "ror     r9, r9, #31",
+
+                // A[x,2] = rot(A[x-2,2], 8)
+                // OPTIMIZATION: Folded rotation into register move using barrel shifter.
+                "mov     r0, r10",
+                "mov     r10, r12, ror #24",
+                "mov     r12, r0,  ror #24",
+                "mov     r0, r11",
+                "mov     r11, lr,  ror #24",
+                "mov     lr,  r0,  ror #24",
+
+                // Loop control
+                "subs    r1, r1, #1",
+                "bne     0b",
+
+                // Store state back
+                "ldr     r0, [sp, #4]",
+                "stmia   r0, {{r2-r12, lr}}",
+
+                "pop     {{r0, r1}}",                       // Discard rk, st
+                "pop     {{r4-r11, lr}}",
+
+                rk = in(reg) rkeys,
+                st = in(reg) st_ptr,
+                out("r0") _, out("r1") _, out("r2") _, out("r3") _,
+                out("r12") _,
+            );
+        }
+    }
+}

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -57,7 +57,7 @@ impl Xoodoo {
         for st_word in &mut st_words {
             *st_word = (*st_word).to_le()
         }
-        self.from_words(&st_words);
+        self.init_from_words(st_words);
     }
 
     #[cfg(target_endian = "little")]

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -1,8 +1,13 @@
 use core::convert::TryInto;
 use zeroize::Zeroize;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(
+    target_arch = "x86_64",
+    all(target_arch = "arm", target_endian = "little", thumb2),
+)))]
 mod impl_portable;
+#[cfg(all(target_arch = "arm", target_endian = "little", thumb2))]
+mod impl_thumb2;
 #[cfg(target_arch = "x86_64")]
 mod impl_x86_64;
 

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -3,6 +3,7 @@ use zeroize::Zeroize;
 
 #[cfg(not(any(
     target_arch = "x86_64",
+    target_arch = "riscv32",
     all(target_arch = "arm", target_endian = "little", any(thumb1, thumb2)),
 )))]
 mod impl_portable;
@@ -12,6 +13,8 @@ mod impl_thumb1;
 mod impl_thumb2;
 #[cfg(target_arch = "x86_64")]
 mod impl_x86_64;
+#[cfg(target_arch = "riscv32")]
+mod impl_riscv32;
 
 const ROUND_KEYS: [u32; 12] = [
     0x058, 0x038, 0x3c0, 0x0d0, 0x120, 0x014, 0x060, 0x02c, 0x380, 0x0f0, 0x1a0, 0x012,

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -3,9 +3,11 @@ use zeroize::Zeroize;
 
 #[cfg(not(any(
     target_arch = "x86_64",
-    all(target_arch = "arm", target_endian = "little", thumb2),
+    all(target_arch = "arm", target_endian = "little", any(thumb1, thumb2)),
 )))]
 mod impl_portable;
+#[cfg(all(target_arch = "arm", target_endian = "little", thumb1))]
+mod impl_thumb1;
 #[cfg(all(target_arch = "arm", target_endian = "little", thumb2))]
 mod impl_thumb2;
 #[cfg(target_arch = "x86_64")]

--- a/src/xoodoo/mod.rs
+++ b/src/xoodoo/mod.rs
@@ -11,6 +11,7 @@ const ROUND_KEYS: [u32; 12] = [
 ];
 
 #[derive(Clone, Debug)]
+#[repr(align(4))]
 pub struct Xoodoo {
     st: [u8; 48],
 }

--- a/src/xoodyak/any.rs
+++ b/src/xoodyak/any.rs
@@ -1,6 +1,9 @@
 use super::internal::{Mode, Phase};
 use super::*;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 #[derive(Clone, Debug)]
 pub enum XoodyakAny {
     Hash(XoodyakHash),
@@ -154,19 +157,19 @@ impl XoodyakAny {
         self.keyed()?.aead_decrypt_in_place(in_out)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn encrypt_to_vec(&mut self, bin: &[u8]) -> Result<Vec<u8>, Error> {
         self.keyed()?.encrypt_to_vec(bin)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn decrypt_to_vec(&mut self, bin: &[u8]) -> Result<Vec<u8>, Error> {
         self.keyed()?.decrypt_to_vec(bin)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn aead_encrypt_to_vec_detached(
         &mut self,
@@ -176,19 +179,19 @@ impl XoodyakAny {
         self.keyed()?.aead_encrypt_to_vec_detached(bin)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn aead_encrypt_to_vec(&mut self, bin: Option<&[u8]>) -> Result<Vec<u8>, Error> {
         self.keyed()?.aead_encrypt_to_vec(bin)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn aead_encrypt_in_place_to_vec(&mut self, in_out: Vec<u8>) -> Result<Vec<u8>, Error> {
         Ok(self.keyed()?.aead_encrypt_in_place_to_vec(in_out))
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn aead_decrypt_to_vec_detached(
         &mut self,
@@ -199,13 +202,13 @@ impl XoodyakAny {
         self.keyed()?.aead_decrypt_to_vec_detached(auth_tag, bin)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn aead_decrypt_to_vec(&mut self, bin: &[u8]) -> Result<Vec<u8>, Error> {
         self.keyed()?.aead_decrypt_to_vec(bin)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn aead_decrypt_in_place_to_vec(&mut self, in_out: Vec<u8>) -> Result<Vec<u8>, Error> {
         self.keyed()?.aead_decrypt_in_place_to_vec(in_out)

--- a/src/xoodyak/any.rs
+++ b/src/xoodyak/any.rs
@@ -59,7 +59,7 @@ impl XoodyakAny {
     fn keyed(&mut self) -> Result<&mut XoodyakKeyed, Error> {
         match self {
             XoodyakAny::Hash(_) => Err(Error::KeyRequired),
-            XoodyakAny::Keyed(ref mut x) => Ok(x),
+            XoodyakAny::Keyed(x) => Ok(x),
         }
     }
 

--- a/src/xoodyak/keyed.rs
+++ b/src/xoodyak/keyed.rs
@@ -2,6 +2,9 @@ use super::internal::XoodyakCommon as _;
 use super::internal::{Mode, Phase};
 use super::*;
 
+#[cfg(feature = "alloc")]
+use alloc::{vec, vec::Vec};
+
 #[derive(Clone, Debug)]
 pub struct XoodyakKeyed {
     state: Xoodoo,
@@ -277,21 +280,21 @@ impl XoodyakKeyed {
         Ok(ct)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn encrypt_to_vec(&mut self, bin: &[u8]) -> Result<Vec<u8>, Error> {
         let mut out = vec![0u8; bin.len()];
         self.encrypt(&mut out, bin)?;
         Ok(out)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn decrypt_to_vec(&mut self, bin: &[u8]) -> Result<Vec<u8>, Error> {
         let mut out = vec![0u8; bin.len()];
         self.decrypt(&mut out, bin)?;
         Ok(out)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn aead_encrypt_to_vec_detached(
         &mut self,
 
@@ -302,14 +305,14 @@ impl XoodyakKeyed {
         Ok((out, auth_tag))
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn aead_encrypt_to_vec(&mut self, bin: Option<&[u8]>) -> Result<Vec<u8>, Error> {
         let mut out = vec![0u8; bin.unwrap_or_default().len() + AUTH_TAG_BYTES];
         self.aead_encrypt(&mut out, bin)?;
         Ok(out)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn aead_encrypt_in_place_to_vec(&mut self, mut in_out: Vec<u8>) -> Vec<u8> {
         let ct_len = in_out.len();
         in_out.resize_with(ct_len + AUTH_TAG_BYTES, || 0);
@@ -317,7 +320,7 @@ impl XoodyakKeyed {
         in_out
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn aead_decrypt_to_vec_detached(
         &mut self,
         auth_tag: Tag,
@@ -328,7 +331,7 @@ impl XoodyakKeyed {
         Ok(out)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn aead_decrypt_to_vec(&mut self, bin: &[u8]) -> Result<Vec<u8>, Error> {
         let ct_len = bin
             .len()
@@ -339,7 +342,7 @@ impl XoodyakKeyed {
         Ok(out)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub fn aead_decrypt_in_place_to_vec(&mut self, mut in_out: Vec<u8>) -> Result<Vec<u8>, Error> {
         let ct_len = in_out
             .len()

--- a/src/xoodyak/mod.rs
+++ b/src/xoodyak/mod.rs
@@ -12,6 +12,9 @@ pub use tag::*;
 use crate::error::*;
 use crate::xoodoo::*;
 
+#[cfg(feature = "alloc")]
+use alloc::{vec, vec::Vec};
+
 pub(crate) const HASH_ABSORB_RATE: usize = 16;
 pub(crate) const HASH_SQUEEZE_RATE: usize = 16;
 pub(crate) const KEYED_ABSORB_RATE: usize = 44;
@@ -148,7 +151,7 @@ pub trait XoodyakCommon: internal::XoodyakCommon {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn squeeze_to_vec(&mut self, len: usize) -> Vec<u8> {
         let mut out = vec![0u8; len];
         self.squeeze(&mut out);


### PR DESCRIPTION
## Description

This PR refactors the crate to run unconditionally as `#![no_std]` by default, transitions heap-allocated helper APIs to a new optional `alloc` feature, implements the standard `core::error::Error` trait, and upgrades the crate to **Rust Edition 2024**.

These changes improve compatibility for constrained environments and align the crate with modern Rust best practices.

---

## Key Changes

### 1. Upgrade to Rust Edition 2024
* Upgraded package edition in `Cargo.toml` from `2018` to `2024`.
* Refactored pattern matching in `XoodyakAny::keyed` (`src/xoodyak/any.rs`) to align with Rust 2024's implicit borrow rules (removing `ref mut` when matching on a mutable reference).

### 2. Unconditional `no_std` & `alloc` Feature
* Removed the `std` feature in `Cargo.toml` completely.
* Declared `#![no_std]` unconditionally in `src/lib.rs`.
* Introduced a new `alloc` feature mapped to `zeroize/alloc`.
* Moved heap-allocated convenience helper methods (`encrypt_to_vec`, `decrypt_to_vec`, `aead_encrypt_to_vec`, `squeeze_to_vec`, etc.) under `#[cfg(feature = "alloc")]` (importing `Vec` and `vec!` from the standard `alloc` crate).

### 3. Modernized Error Handling
* Implemented `core::error::Error` unconditionally for the `Error` enum (`src/error.rs`). Since Rust 1.81.0, the `Error` trait is available in the `core` library and no longer requires `std`.

### 4. Tests
* Added a dedicated `test_alloc_to_vec` test under `#[cfg(feature = "alloc")]` in `src/test.rs` to verify the heap-allocated helper functions.

---

## ⚠️ Breaking Changes

* **MSRV Bump**: This crate now requires **Rust 1.85.0+** due to the Rust 2024 edition upgrade.
* **Feature Defaults**: `std` is no longer a default feature. Downstream crates that rely on heap methods (like `*_to_vec`) must explicitly specify the `alloc` feature:
  ```toml
  xoodyak = { features = ["alloc"] }
  ```